### PR TITLE
fix: local ghost, algolia, dayjs, and other bugs

### DIFF
--- a/_site/english/news/index.html
+++ b/_site/english/news/index.html
@@ -1,4 +1,0 @@
-<!doctype html>
-  <meta http-equiv="refresh" content="0; url=/">
-  <title>Browsersync pathPrefix Redirect</title>
-  <a href="/">Go to /</a>

--- a/config/index.js
+++ b/config/index.js
@@ -67,8 +67,8 @@ const computedDomain = siteDomain || 'freecodecamp.org';
 const computedPath = (lang === 'english' || lang === 'chinese') ? 'news' : `${lang}/news`;
 let siteURL;
 
-if (localeForGhost === 'local') {
-  siteURL = `http://${siteDomain}/${computedPath}`;
+if (computedDomain.startsWith('localhost')) {
+  siteURL = `http://${computedDomain}/${computedPath}`;
 } else if (lang === 'chinese') {
   siteURL = `https://chinese.${computedDomain}/${computedPath}`;
 } else {

--- a/config/index.js
+++ b/config/index.js
@@ -39,11 +39,11 @@ const {
 } = process.env;
 
 // Validations
-const lang = locales.find((e) => e === localeForGhost);
+const lang = locales.find((e) => e === localeForUI);
 if (!lang) {
-  throw new Error(`Unsupported locale: ${localeForGhost}`);
+  throw new Error(`Unsupported locale: ${localeForUI}`);
 }
-if (lang !== localeForUI) {
+if (lang !== localeForGhost && localeForGhost !== 'local') {
   console.warn(`
     ----------------------------------------------------
     Warning: Mismatch between UI locale and Ghost locale.
@@ -56,10 +56,16 @@ if (lang !== localeForUI) {
 
 // Config Computations
 const computedDomain = siteDomain || 'freecodecamp.org';
-const siteURL =
-  lang !== 'chinese'
-    ? `https://www.${computedDomain}/${lang}/news`
-    : `https://chinese.${computedDomain}/news`;
+const computedPath = (lang === 'english' || lang === 'chinese') ? 'news' : `${lang}/news`;
+let siteURL;
+
+if (localeForGhost === 'local') {
+  siteURL = `http://${siteDomain}/${computedPath}`;
+} else if (lang === 'chinese') {
+  siteURL = `https://chinese.${computedDomain}/${computedPath}`;
+} else {
+  siteURL = `https://www.${computedDomain}/${computedPath}`;
+}
 
 module.exports = Object.assign(
   {},

--- a/config/index.js
+++ b/config/index.js
@@ -29,6 +29,14 @@ const localeCodes = {
   portuguese: 'pt-BR'
 };
 
+const algoliaIndices = {
+  english: 'news',
+  espanol: 'news-es',
+  chinese: 'news-zh',
+  italian: 'news-it',
+  portuguese: 'news-pt-br'
+};
+
 const {
   LOCALE_FOR_UI: localeForUI,
   LOCALE_FOR_GHOST: localeForGhost,
@@ -84,6 +92,7 @@ module.exports = Object.assign(
     algoliaAPIKey:
       !algoliaAPIKey || algoliaAPIKey === 'api_key_from_algolia_dashboard'
         ? ''
-        : algoliaAPIKey
+        : algoliaAPIKey,
+    algoliaIndex: algoliaIndices[localeForUI] || 'news'
   }
 );

--- a/i18n/locales/italian/translations.json
+++ b/i18n/locales/italian/translations.json
@@ -30,7 +30,7 @@
   "tag-page": {
     "collection-of-posts": "Una collezione di articoli",
     "one-post": "Una collezione di 1 articolo",
-    "multiple-posts": "Una collezione di % articoli"
+    "multiple-posts": "Una collezione di {{ postCount }} articoli"
   },
   "404-page": {
     "page-not-found": "Pagina non trovata",

--- a/src/_data/secrets.js
+++ b/src/_data/secrets.js
@@ -1,6 +1,7 @@
-const { algoliaAppId, algoliaAPIKey } = require('../../config');
+const { algoliaAppId, algoliaAPIKey, algoliaIndex } = require('../../config');
 
 module.exports = {
   algoliaAppId, 
-  algoliaAPIKey
+  algoliaAPIKey,
+  algoliaIndex
 }

--- a/src/_data/secrets.js
+++ b/src/_data/secrets.js
@@ -1,5 +1,6 @@
-const { algoliaAppId, algoliaApiKey } = require('../../config');
+const { algoliaAppId, algoliaAPIKey } = require('../../config');
+
 module.exports = {
   algoliaAppId, 
-  algoliaApiKey
+  algoliaAPIKey
 }

--- a/src/_includes/assets/js/algolia-locale-setup.js
+++ b/src/_includes/assets/js/algolia-locale-setup.js
@@ -2,14 +2,6 @@
 let client, index;
 
 document.addEventListener('DOMContentLoaded', () => {
-  const algoliaIndices = {
-    en: 'news',
-    es: 'news-es',
-    zh: 'news-zh',
-    'pt-br': 'news-pt-br',
-    it: 'news-it'
-  };
-
   // load Algolia and set index globally
   // eslint-disable-next-line no-undef
   client = algoliasearch(
@@ -17,5 +9,5 @@ document.addEventListener('DOMContentLoaded', () => {
     '{{ secrets.algoliaAPIKey }}'
   );
 
-  index = client.initIndex(algoliaIndices['{{ site.lang }}']);
+  index = client.initIndex('{{ secrets.algoliaIndex }}');
 });

--- a/src/_includes/assets/js/algolia-locale-setup.js
+++ b/src/_includes/assets/js/algolia-locale-setup.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // eslint-disable-next-line no-undef
   client = algoliasearch(
     '{{ secrets.algoliaAppId }}',
-    '{{ secrets.algoliaApiKey }}'
+    '{{ secrets.algoliaAPIKey }}'
   );
 
   index = client.initIndex(algoliaIndices['{{ site.lang }}']);

--- a/src/_includes/assets/js/client-dayjs.js
+++ b/src/_includes/assets/js/client-dayjs.js
@@ -3,5 +3,5 @@ document.addEventListener('DOMContentLoaded', () => {
   // Load dayjs plugins and set locale
   dayjs.extend(dayjs_plugin_localizedFormat);
   dayjs.extend(dayjs_plugin_relativeTime);
-  dayjs.locale('{{ site.lang }}');
+  dayjs.locale('{{ site.lang | lower }}');
 });

--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -33,8 +33,8 @@
         <script defer src="https://cdn.freecodecamp.org/news-assets/dayjs/1.10.4/relativeTime.min.js"></script>
 
         {# Dynamically load Day.js locale #}
-        {% if not siteLang === "en" %}
-            <script defer src="https://cdn.freecodecamp.org/news-assets/dayjs/1.10.4/locale/{{ site.lang }}.min.js"></script>
+        {% if siteLang !== "en" %}
+            <script defer src="https://cdn.freecodecamp.org/news-assets/dayjs/1.10.4/locale/{{ site.lang | lower }}.min.js"></script>
         {% endif %}
 
         {# Lazysizes #}

--- a/src/_includes/partials/author-info.njk
+++ b/src/_includes/partials/author-info.njk
@@ -68,7 +68,7 @@
         {% endif %}
         <a
             class="social-link social-link-rss"
-            href="https://feedly.com/i/subscription/feed/{{ author.absolute_url }}rss/"
+            href="https://feedly.com/i/subscription/feed/{{ author.url }}rss/"
             target="_blank"
             rel="noopener"
         >


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This makes a few changes, like using `localeForUI` instead of `localeForGhost` to set the `lang` variable. The other main change is to handle cases where Ghost is running locally, and to compute the path based on the value of `lang`.

But I'd be happy to rework this to go back to the current method of setting `lang` based on `localeForGhost`, though.

The other fixes include moving more of the Algolia setup into `config/index.js`, and the dynamic Day.js script in `default.njk` and its config.