### PR TITLE
fix: remove feature image from amp pages

### DIFF
--- a/cypress/integration/english/amp/amp.spec.js
+++ b/cypress/integration/english/amp/amp.spec.js
@@ -6,4 +6,8 @@ describe('Amp page', () => {
   it('should render', () => {
     cy.contains("We're Building New Courses on Rust and Python + the Replit.web Framework");
   });
+
+  it('should not show a feature image', () => {
+    cy.get('figure.post-image amp-img').should('not.exist');
+  });
 });

--- a/src/_includes/layouts/amp.njk
+++ b/src/_includes/layouts/amp.njk
@@ -112,11 +112,6 @@
                     </time>
                 </section>
             </header>
-            {% if post.feature_image %}
-                <figure class="post-image">
-                    <amp-img src="{{ post.feature_image }}" width="600" height="400" layout="responsive"></amp-img>
-                </figure>
-            {% endif %}
             <section class="post-content {{ "medium-migrated-article" if (post.primary_author.name == "freeCodeCamp.org") }}">
                 {{ content | safe }}
             </section>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #101 

<!-- Feel free to add any additional description of changes below this line -->
Small change here. This just removes feature images from the AMP pages, and adds a test to ensure they don't exist.