### PR TITLE
fix: push ads on window load event

### DIFF
--- a/src/_includes/partials/ad.njk
+++ b/src/_includes/partials/ad.njk
@@ -8,7 +8,7 @@
     ></ins>
 </div>
 <script>
-    document.addEventListener('DOMContentLoaded', () => {
+    window.addEventListener('load', () => {
         if (notAuthenticated) (adsbygoogle = window.adsbygoogle || []).push({});
     });
 </script>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Currently loading ads is a bit inconsistent, and AdSense sometimes throws errors like that read `adsbygoogle.push() error: No slot size for availableWidth=0`.

Right now we use an "authenticated first" model, where the ad sidebar and bottom banner ad start off collapsed, and we expand those after determining that the reader isn't authenticated.

This seems to create a race condition where the ads are successfully populated if the styles are parsed and applied before the ad code runs. If the ad code runs before that, we get the error.

Waiting for the `load` event should prevent this.