### PR TITLE
fix: handle trailing slash for next page meta

### DIFF
--- a/src/_includes/assets/js/pagination.js
+++ b/src/_includes/assets/js/pagination.js
@@ -6,7 +6,9 @@
   const fetchNextPage = async () => {
     try {
       const nextTag = document.querySelector('link[rel="next"]');
-      const nextPageUrl = `${window.location.href}${nextPageNum}/`;
+      let href = window.location.href;
+      if (!href.endsWith('/')) href = `${href}/`
+      const nextPageUrl = `${href}${nextPageNum}/`;
       const res = await fetch(nextPageUrl);
 
       if (nextTag) nextTag.href = nextPageUrl;
@@ -16,7 +18,7 @@
         const parser = new DOMParser();
 
         nextPageNum++;
-        return await parser.parseFromString(text, 'text/html');
+        return parser.parseFromString(text, 'text/html');
       } else {
         readMoreBtn.style.display = 'none';
       }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR should fix the `<link rel="next" ...>` tags for versions of the URL without the trailing slash. It also removes an unnecessary `await`.

Currently, this tag on https://www.freecodecamp.org/portuguese/news shows `<link rel="next" href="https://www.freecodecamp.org/portuguese/news1/">`, where the `href` attribute should be `https://www.freecodecamp.org/portuguese/news/1/`.

It will be difficult to test this locally because Browsersync automatically redirects from URLs without the trailing slash to versions with the trailing slash (https://www.freecodecamp.org/portuguese/news --> https://www.freecodecamp.org/portuguese/news/). But this change should properly update the tag for both URLs.