### PR TITLE
feat: add NGINX redirect to the trailing slash version of the URL

### DIFF
--- a/mock-www/nginx.conf
+++ b/mock-www/nginx.conf
@@ -17,6 +17,14 @@ server {
    try_files $uri /dothraki/index.html;
  }
 
+ location ~ ^/dothraki/news/([^.\?]*[^/])$ {
+   try_files $uri @addslash;
+ }
+
+ location @addslash {
+   return 301 $uri/;
+ }
+
  location /dothraki/news/ {
    proxy_pass http://news/;
    proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This should mimic the behavior of Ghost, which does a 301 redirect to add a trailing slash to URLs that aren't files (don't end in `.ext`). For example, https://www.freecodecamp.org/news/how-to-create-a-custom-patreon-button --> https://www.freecodecamp.org/news/how-to-create-a-custom-patreon-button/.

Currently we're not doing this for any of the JAMStack News sites. All the canonical URLs and the sitemaps should use trailing slash versions of each URL, which _should_ prevent Google from flagging our sites for duplicate content, at least in theory.

Still, implementing a redirect to one version of the page is suggested here: https://developers.google.com/search/blog/2010/04/to-slash-or-not-to-slash

Also, I don't believe it's possible to do this with the `trailingSlash` feature in `serve`. It redirects from https://www.freecodecamp.org/news/how-to-create-a-custom-patreon-button to https://www.freecodecamp.org/how-to-create-a-custom-patreon-button/, and there doesn't seem to be a way to change the base path for each site (`/news/...` or `/lang/news/...`).

This PR is to open up a discussion over whether or not we want to handle redirects like this in NGINX or not, and if so, how to handle them. I'm not sure if this exact config would work across all the different News sites, and we may need to use specific named locations (`@dothrakiaddslash`, `@englishaddslash`, and so on).