### PR TITLE
fix: image styling when ads are enabled / disabled

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -907,8 +907,22 @@ make sure this only happens on large viewports / desktop-ish devices.
 .post-full-content video {
   display: block;
   margin: 1.5em auto;
-  max-width: 100%;
+  max-width: 1040px;
   height: auto;
+}
+
+@media (max-width: 1040px) {
+  .post-full-content img,
+  .post-full-content video {
+    width: 100%;
+  }
+}
+
+/* Adjust image body and video widths when ads are enabled */
+
+.ad-layout .post-full-content img,
+.ad-layout .post-full-content video {
+  width: 100%;
 }
 
 /* Image captions
@@ -2361,10 +2375,6 @@ a.banner:hover span {
 /* Apply the following styles for unauthenticated readers */
 .ad-layout .banner-ad {
   display: block;
-}
-
-.ad-layout .kg-width-wide .kg-image {
-  max-width: 720px;
 }
 
 /* Hide unfilled ads */


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR includes a minor reversion of the changes in #151 so image and video widths are the same as they were in the Ghost News theme when ads are disabled. If a reader is authenticated, things should look just as they did with the older theme.

The main issue when ads are enabled are "wide" images, which are set in the Ghost editor. The wide setting allows images to slightly overflow the content container, which is fine when ads are disabled, but could cause issues when ads are enabled and the sidebar is present.

Small images with widths that don't overflow the main content container should be fine whether ads are enabled or disabled.

The changes here should resize images and videos specifically when ads are enabled, and make further refinements for mobile.

Here are screenshots to help with the review process:

### Reader authenticated / ads disabled:

#### Desktop

- Large image with caption:
![image](https://user-images.githubusercontent.com/2051070/151648188-cb421379-c0f5-48a0-bb54-66bd955bf8cd.png)

- Large image without caption:
![image](https://user-images.githubusercontent.com/2051070/151648320-2e731241-0d64-4f98-89b2-cbb1f644b9a4.png)

#### Mobile

- Large image with caption:
![image](https://user-images.githubusercontent.com/2051070/151648277-7b203a4b-d0d0-44ef-afcf-516b7e8dc84c.png)

- Large image without caption:
![image](https://user-images.githubusercontent.com/2051070/151648348-e5ddc97b-558f-4a45-a341-0d3a6c7c3240.png)

### Reader unauthenticated / ads enabled:

#### Desktop

- Large image with caption:
![image](https://user-images.githubusercontent.com/2051070/151648649-e5f36495-81c9-4589-8050-49012fa374b5.png)

- Large image without caption:
![image](https://user-images.githubusercontent.com/2051070/151648702-de182ddd-b200-4ad4-8ac5-0e7f0163cb7f.png)

#### Mobile

- Large image with caption:
![image](https://user-images.githubusercontent.com/2051070/151648675-ea3e84ce-86e6-4d37-a758-08fbececa7ae.png)

- Large image without caption:
![image](https://user-images.githubusercontent.com/2051070/151648683-58908a03-9e28-4941-920d-37b35162bf95.png)