### PR TITLE
i18n: update links for Japanese pages

### DIFF
--- a/i18n/locales/japanese/links.json
+++ b/i18n/locales/japanese/links.json
@@ -1,8 +1,8 @@
 {
   "forum": "https://forum.freecodecamp.org/c/japanese/552",
-  "donate": "https://www.freecodecamp.org/donate/",
-  "banner": "https://www.freecodecamp.org/",
-  "learn-to-code-cta": "https://www.freecodecamp.org/learn/",
+  "donate": "https://www.freecodecamp.org/japanese/donate/",
+  "banner": "https://www.freecodecamp.org/japanese/",
+  "learn-to-code-cta": "https://www.freecodecamp.org/japanese/learn/",
   "twitter": "https://twitter.com/freecodecampJA",
   "footer": {
     "about": "https://www.freecodecamp.org/japanese/news/about/",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

Updating links for "donate", "banner", and "learn-to-code-cta"

Note: Currently, the donate & learn URLs are redirected to English page when they have `/` at the end. But I kept it to conform with other language files.