### PR TITLE
fix: number of posts on author and tag pages

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -25,6 +25,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
 
+      - name: Set environment variables
+        run: cp sample.env .env
+
       - name: Install dependencies
         run: npm ci
 

--- a/cypress/integration/english/author/author.spec.js
+++ b/cypress/integration/english/author/author.spec.js
@@ -19,8 +19,8 @@ describe("Author page", () => {
     cy.get(selectors.authorPostCount).should("be.visible");
   });
 
-  it(`should show ${Cypress.env("postsPerPage")} posts on load`, () => {
-    cy.getPostCards().should("have.length", Cypress.env("postsPerPage"));
+  it(`should show 25 posts on load`, () => {
+    cy.getPostCards().should("have.length", 25);
   });
 
   it("should show the correct number of total posts", () => {

--- a/cypress/integration/english/author/author.spec.js
+++ b/cypress/integration/english/author/author.spec.js
@@ -19,7 +19,15 @@ describe("Author page", () => {
     cy.get(selectors.authorPostCount).should("be.visible");
   });
 
-  it("should not show the author's location and post count screens < 500px", () => {
+  it(`should show ${Cypress.env("postsPerPage")} posts on load`, () => {
+    cy.getPostCards().should("have.length", Cypress.env("postsPerPage"));
+  });
+
+  it("should show the correct number of total posts", () => {
+    cy.loadAndSumAllPostCards(selectors.authorPostCount);
+  });
+
+  it("should not show the author's location and post count on screens < 500px", () => {
     cy.viewport(499, 660);
     cy.get(selectors.authorLocation).should("not.be.visible");
     cy.get(selectors.authorPostCount).should("not.be.visible");

--- a/cypress/integration/english/author/author.spec.js
+++ b/cypress/integration/english/author/author.spec.js
@@ -1,3 +1,8 @@
+const {
+  getPostCards,
+  loadAndSumAllPostCards,
+} = require("../../../support/utils/post-cards");
+
 const selectors = {
   authorName: "[data-test-label='author-name']",
   authorLocation: "[data-test-label='author-location']",
@@ -20,11 +25,11 @@ describe("Author page", () => {
   });
 
   it(`should show 25 posts on load`, () => {
-    cy.getPostCards().should("have.length", 25);
+    getPostCards().should("have.length", 25);
   });
 
   it("should show the correct number of total posts", () => {
-    cy.loadAndSumAllPostCards(selectors.authorPostCount);
+    loadAndSumAllPostCards(selectors.authorPostCount);
   });
 
   it("should not show the author's location and post count on screens < 500px", () => {

--- a/cypress/integration/english/author/author.spec.js
+++ b/cypress/integration/english/author/author.spec.js
@@ -1,6 +1,6 @@
 const {
   getPostCards,
-  loadAndSumAllPostCards,
+  loadAndCountAllPostCards,
 } = require("../../../support/utils/post-cards");
 
 const selectors = {
@@ -29,7 +29,7 @@ describe("Author page", () => {
   });
 
   it("should show the correct number of total posts", () => {
-    loadAndSumAllPostCards(selectors.authorPostCount);
+    loadAndCountAllPostCards(selectors.authorPostCount);
   });
 
   it("should not show the author's location and post count on screens < 500px", () => {

--- a/cypress/integration/english/tag/tag.spec.js
+++ b/cypress/integration/english/tag/tag.spec.js
@@ -1,6 +1,6 @@
 const {
   getPostCards,
-  loadAndSumAllPostCards,
+  loadAndCountAllPostCards,
 } = require("../../../support/utils/post-cards");
 
 const selectors = {
@@ -23,6 +23,6 @@ describe("Tag page", () => {
   });
 
   it("should show the correct number of total posts", () => {
-    loadAndSumAllPostCards(selectors.tagPostCount);
+    loadAndCountAllPostCards(selectors.tagPostCount);
   });
 });

--- a/cypress/integration/english/tag/tag.spec.js
+++ b/cypress/integration/english/tag/tag.spec.js
@@ -1,5 +1,6 @@
 const selectors = {
   tagName: "[data-test-label='tag-name']",
+  tagPostCount: "[data-test-label='tag-post-count']",
 };
 
 describe("Tag page", () => {
@@ -9,5 +10,14 @@ describe("Tag page", () => {
 
   it("should render", () => {
     cy.contains(selectors.tagName, "#FREECODECAMP");
+  });
+
+  // To do: run tests against a tag with more total posts
+  it(`should show 7 posts on load`, () => {
+    cy.getPostCards().should("have.length", 7);
+  });
+
+  it("should show the correct number of total posts", () => {
+    cy.loadAndSumAllPostCards(selectors.tagPostCount);
   });
 });

--- a/cypress/integration/english/tag/tag.spec.js
+++ b/cypress/integration/english/tag/tag.spec.js
@@ -1,3 +1,8 @@
+const {
+  getPostCards,
+  loadAndSumAllPostCards,
+} = require("../../../support/utils/post-cards");
+
 const selectors = {
   tagName: "[data-test-label='tag-name']",
   tagPostCount: "[data-test-label='tag-post-count']",
@@ -14,10 +19,10 @@ describe("Tag page", () => {
 
   // To do: run tests against a tag with more total posts
   it(`should show 7 posts on load`, () => {
-    cy.getPostCards().should("have.length", 7);
+    getPostCards().should("have.length", 7);
   });
 
   it("should show the correct number of total posts", () => {
-    cy.loadAndSumAllPostCards(selectors.tagPostCount);
+    loadAndSumAllPostCards(selectors.tagPostCount);
   });
 });

--- a/cypress/integration/english/tag/tag.spec.js
+++ b/cypress/integration/english/tag/tag.spec.js
@@ -19,7 +19,7 @@ describe("Tag page", () => {
 
   // To do: run tests against a tag with more total posts
   it(`should show 7 posts on load`, () => {
-    getPostCards().should("have.length", 7);
+    getPostCards().should("have.length.gte", 7);
   });
 
   it("should show the correct number of total posts", () => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,22 +1,7 @@
-/// <reference types="cypress" />
-// ***********************************************************
-// This example plugins/index.js can be used to load plugins
-//
-// You can change the location of this file or turn off loading
-// the plugins file with the 'pluginsFile' configuration option.
-//
-// You can read more here:
-// https://on.cypress.io/plugins-guide
-// ***********************************************************
+const { postsPerPage } = require("../../config");
 
-// This function is called when a project is opened or re-opened (e.g. due to
-// the project's config changing)
-
-/**
- * @type {Cypress.PluginConfig}
- */
-// eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+  config.env.postsPerPage = postsPerPage;
+
+  return config;
 };

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -9,14 +9,10 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
-// This function is called when a project is opened or re-opened (e.g. due to
-// the project's config changing)
+const { postsPerPage } = require("../../config");
 
-/**
- * @type {Cypress.PluginConfig}
- */
-// eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
-  // `on` is used to hook into various events Cypress emits
-  // `config` is the resolved Cypress config
+  config.env.postsPerPage = postsPerPage;
+
+  return config;
 };

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -9,10 +9,14 @@
 // https://on.cypress.io/plugins-guide
 // ***********************************************************
 
-const { postsPerPage } = require("../../config");
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
 
+/**
+ * @type {Cypress.PluginConfig}
+ */
+// eslint-disable-next-line no-unused-vars
 module.exports = (on, config) => {
-  config.env.postsPerPage = postsPerPage;
-
-  return config;
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
 };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,7 +25,7 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
 const calculateClicks = (total) => {
-  const postsPerPage = Number(Cypress.env("postsPerPage"));
+  const postsPerPage = 25;
 
   // If returning the num of clicks, subtract 1 because the first page is
   // fully populated

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,35 +23,3 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
-
-const calculateClicks = (total) => {
-  const postsPerPage = 25;
-
-  // If returning the num of clicks, subtract 1 because the first page is
-  // fully populated
-  return total <= postsPerPage ? 0 : Math.ceil(total / postsPerPage) - 1;
-};
-
-Cypress.Commands.add("getPostCards", () => {
-  cy.get(".post-feed").find(".post-card");
-});
-
-Cypress.Commands.add("loadAndSumAllPostCards", (selector) => {
-  cy.get(selector)
-    .invoke("text")
-    .then((text) => {
-      const loadMoreSelector = "[data-test-label='load-more-articles-button']";
-      const totalPosts = Number(text.trim().match(/\d+/)[0]);
-      let numOfClicks = calculateClicks(totalPosts);
-
-      cy.intercept("GET", /\/news\/(author|tag)\/.+\/\d+/).as("fetchNextPage");
-
-      Cypress._.times(numOfClicks, () => {
-        cy.get(loadMoreSelector).click();
-
-        cy.wait("@fetchNextPage");
-      });
-
-      cy.getPostCards().should("have.length", totalPosts);
-    });
-});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,35 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+const calculateClicks = (total) => {
+  const postsPerPage = Number(Cypress.env("postsPerPage"));
+
+  // If returning the num of clicks, subtract 1 because the first page is
+  // fully populated
+  return total <= postsPerPage ? 0 : Math.ceil(total / postsPerPage) - 1;
+};
+
+Cypress.Commands.add("getPostCards", () => {
+  cy.get(".post-feed").find(".post-card");
+});
+
+Cypress.Commands.add("loadAndSumAllPostCards", (selector) => {
+  cy.get(selector)
+    .invoke("text")
+    .then((text) => {
+      const loadMoreSelector = "[data-test-label='load-more-articles-button']";
+      const totalPosts = Number(text.trim().match(/\d+/)[0]);
+      let numOfClicks = calculateClicks(totalPosts);
+
+      cy.intercept("GET", /\/news\/(author|tag)\/.+\/\d+/).as("fetchNextPage");
+
+      Cypress._.times(numOfClicks, () => {
+        cy.get(loadMoreSelector).click();
+
+        cy.wait("@fetchNextPage");
+      });
+
+      cy.getPostCards().should("have.length", totalPosts);
+    });
+});

--- a/cypress/support/utils/post-cards.js
+++ b/cypress/support/utils/post-cards.js
@@ -1,0 +1,34 @@
+const calculateClicks = (total) => {
+  const postsPerPage = 25;
+
+  // If returning the num of clicks, subtract 1 because the first page is
+  // fully populated
+  return total <= postsPerPage ? 0 : Math.ceil(total / postsPerPage) - 1;
+};
+
+const getPostCards = () => cy.get(".post-feed").find(".post-card");
+
+const loadAndSumAllPostCards = (selector) => {
+  cy.get(selector)
+    .invoke("text")
+    .then((text) => {
+      const loadMoreSelector = "[data-test-label='load-more-articles-button']";
+      const totalPosts = Number(text.trim().match(/\d+/)[0]);
+      let numOfClicks = calculateClicks(totalPosts);
+
+      cy.intercept("GET", /\/news\/(author|tag)\/.+\/\d+/).as("fetchNextPage");
+
+      Cypress._.times(numOfClicks, () => {
+        cy.get(loadMoreSelector).click();
+
+        cy.wait("@fetchNextPage");
+      });
+
+      getPostCards().should("have.length", totalPosts);
+    });
+};
+
+module.exports = {
+  getPostCards,
+  loadAndSumAllPostCards,
+};

--- a/cypress/support/utils/post-cards.js
+++ b/cypress/support/utils/post-cards.js
@@ -1,5 +1,5 @@
 const calculateClicks = (total) => {
-  const postsPerPage = 25;
+  const postsPerPage = Cypress.env("postsPerPage");
 
   // If returning the num of clicks, subtract 1 because the first page is
   // fully populated

--- a/cypress/support/utils/post-cards.js
+++ b/cypress/support/utils/post-cards.js
@@ -8,7 +8,7 @@ const calculateClicks = (total) => {
 
 const getPostCards = () => cy.get(".post-feed").find(".post-card");
 
-const loadAndSumAllPostCards = (selector) => {
+const loadAndCountAllPostCards = (selector) => {
   cy.get(selector)
     .invoke("text")
     .then((text) => {
@@ -30,5 +30,5 @@ const loadAndSumAllPostCards = (selector) => {
 
 module.exports = {
   getPostCards,
-  loadAndSumAllPostCards,
+  loadAndCountAllPostCards,
 };

--- a/cypress/support/utils/post-cards.js
+++ b/cypress/support/utils/post-cards.js
@@ -14,7 +14,7 @@ const loadAndSumAllPostCards = (selector) => {
     .then((text) => {
       const loadMoreSelector = "[data-test-label='load-more-articles-button']";
       const totalPosts = Number(text.trim().match(/\d+/)[0]);
-      let numOfClicks = calculateClicks(totalPosts);
+      const numOfClicks = calculateClicks(totalPosts);
 
       cy.intercept("GET", /\/news\/(author|tag)\/.+\/\d+/).as("fetchNextPage");
 

--- a/src/_data/ghost.js
+++ b/src/_data/ghost.js
@@ -156,12 +156,12 @@ module.exports = async () => {
       // Filter out paginated authors / tags if they exist
       .filter((obj) => (obj.page ? obj.page === 0 : obj))
       .map((obj) => {
+        const feedObj = cloneDeep(obj);
         // The main feed shows the last 10 posts. Tag and author
         // pages show the last 15 posts
-        const feedPostLimit = obj.path === "/" ? 10 : 15;
-        const allPosts = cloneDeep(obj.posts);
+        const feedPostLimit = feedObj.path === "/" ? 10 : 15;
 
-        obj.posts = allPosts.slice(0, feedPostLimit).map((post) => {
+        feedObj.posts = feedObj.posts.slice(0, feedPostLimit).map((post) => {
           // Append the feature image to the post content
           if (post.feature_image)
             post.html =
@@ -171,7 +171,7 @@ module.exports = async () => {
           return post;
         });
 
-        return obj;
+        return feedObj;
       });
 
   const feeds = [
@@ -179,11 +179,11 @@ module.exports = async () => {
     getCollectionFeeds([
       {
         path: "/",
-        posts: [...posts],
+        posts,
       },
     ]),
-    getCollectionFeeds([...authors]),
-    getCollectionFeeds([...tags]),
+    getCollectionFeeds(authors),
+    getCollectionFeeds(tags),
   ].flat();
 
   return {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
An author found that the current author and tag pages do not show the correct number of post cards, making it difficult to view all of the posts for any author / tag with more than 15 posts.

This bug was due to unintentionally overwriting the first "chunk" of posts associated with an author or tag while building collections for their RSS feeds, which show 15 of the latest posts for said author / tag.

For example, Ilenia has 28 published articles, but when you go to the author page at https://www.freecodecamp.org/news/author/ilenia/, only 15 posts are visible. Then when you click on the "Load More Articles" button, it only loads 3 articles, for a total of 18.

This PR fixes that bug so up to 25 posts are shown on an article or tag page when first loaded, and adds a couple of tests so we can catch this issue in the future.

Update 1: Seems like this won't work until the commands and plugins are merged. I could submit those as a separate PR if that's easier.

Update 2: Refactored things to use utility functions, and removed the problematic Cypress plugin. The number of posts per page is hardcoded in the tests for now, but we can fix that once we move to Dockerized Ghost for CI.

This should be okay to review now.