### PR TITLE
feat: add ads.txt file for non-Chinese builds

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,4 @@
-const { readFileSync, readdirSync, writeFileSync } = require("fs");
+const { readFileSync, readdirSync, writeFileSync, unlinkSync } = require("fs");
 const pluginRSS = require("@11ty/eleventy-plugin-rss");
 const UpgradeHelper = require("@11ty/eleventy-upgrade-help");
 
@@ -20,6 +20,7 @@ const {
   fullYearShortcode,
   toISOStringShortcode,
 } = require("./utils/shortcodes/dates");
+const { currentLocale_i18n } = require("./config");
 const sitePath = require("./utils/site-path");
 
 module.exports = function (config) {
@@ -37,7 +38,7 @@ module.exports = function (config) {
     manifest = {};
   });
 
-  // Minify CSS
+  // Minify CSS and remove ads.txt from Chinese build
   config.on("afterBuild", () => {
     const path = "./dist/assets/css";
     const cssFiles = readdirSync(path);
@@ -48,6 +49,8 @@ module.exports = function (config) {
 
       writeFileSync(fullPath, cssMin(content));
     });
+
+    if (currentLocale_i18n === "chinese") unlinkSync("./dist/ads.txt");
   });
 
   // RSS and AMP plugins

--- a/src/ads-txt.njk
+++ b/src/ads-txt.njk
@@ -1,0 +1,4 @@
+---
+permalink: 'ads.txt'
+---
+google.com, {{ secrets.googleAdsenseDataAdClient | replace("ca-", "") }}, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This will create an `ads.txt` file at the root of the site for all builds. If the build is for the Chinese site, the `ads.txt` file will be removed during the `afterBuild` event.

It would be better not to create an `ads.txt` file at all if building the Chinese site, but there doesn't seem to be a good way to dynamically set the `permalink` in the frontmatter to false based on the site language.

Also, `googleAdsenseDataAdClient` should probably be named `googleAdsensePublisherID`, and `ca-...` should be set in the templates themselves. But that change will require some updates to the keys and pipelines, so we can handle it later.