### PR TITLE
fix: increase ads per page and add backgrounds to ad containers

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2378,9 +2378,8 @@ a.banner:hover span {
   display: block;
 }
 
-/* Hide unfilled ads */
-.ad-layout ins.adsbygoogle[data-ad-status="unfilled"] {
-  display: none !important;
+.ad-container {
+  background-color: var(--gray05);
 }
 
 /* Display sidebar for desktop readers */

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -6,8 +6,10 @@
 {% set codeinjection_head = post.codeinjection_head %}
 {% set codeinjection_foot = post.codeinjection_foot %}
 {% set adsEnabled = (secrets.adsEnabled === 'true') and (site.lang !== 'zh') %}
-{# Include 2 ads by default, and add 1 ad for every 2 mins of reading time #}
-{% set numOfSidebarAds = ((post.reading_time / 2) + 2) | round(0, 'floor') %}
+{# Include 2 ads by default for all articles. Then add 1 ad for every 2 mins of
+reading time if reading time <= 4 mins. Else, add 1 ad for every 1 min of reading
+time #}
+{% set numOfSidebarAds = (((post.reading_time / 2) if post.reading_time <= 4 else (post.reading_time)) + 2) | round(0, 'floor') %}
 
 {% block content %}
     <main id="site-main" class="post-template site-main outer">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
These changes will add a light gray background to ad containers that contain ads. This may interfere with ads that have a transparent background, but we can adjust as necessary.

Adding the background color and not hiding unfilled ads should make it more clear where ads are placed throughout the page. However, this won't handle cases where an ad blocker removes both the ad and surrounding container.