### PR TITLE
fix: bullet marks on author pages

### DIFF
--- a/cypress/integration/english/author/author.spec.js
+++ b/cypress/integration/english/author/author.spec.js
@@ -1,5 +1,8 @@
 const selectors = {
   authorName: "[data-test-label='author-name']",
+  authorLocation: "[data-test-label='author-location']",
+  authorPostCount: "[data-test-label='author-post-count']",
+  bullet: "[data-test-label='bullet']",
 };
 
 describe("Author page", () => {
@@ -9,5 +12,21 @@ describe("Author page", () => {
 
   it("should render", () => {
     cy.contains(selectors.authorName, "Quincy Larson");
+  });
+
+  it("should show the author's location and post count on larger screens", () => {
+    cy.get(selectors.authorLocation).should("be.visible");
+    cy.get(selectors.authorPostCount).should("be.visible");
+  });
+
+  it("should not show the author's location and post count screens < 500px", () => {
+    cy.viewport(499, 660);
+    cy.get(selectors.authorLocation).should("not.be.visible");
+    cy.get(selectors.authorPostCount).should("not.be.visible");
+  });
+
+  it("should not show any bullet marks on screens < 500px", () => {
+    cy.viewport(499, 660);
+    cy.get(selectors.bullet).should("not.be.visible");
   });
 });

--- a/src/_includes/partials/author-info.njk
+++ b/src/_includes/partials/author-info.njk
@@ -18,9 +18,9 @@
     {% endif %}
     <div class="author-meta">
         {% if author.location %}
-            <div class="author-location">
+            <div class="author-location" data-test-label="author-location">
                 {{ author.location }}
-                <span class="bull">
+                <span class="bull" data-test-label="bullet">
                     &bull;
                 </span>
             </div>
@@ -33,7 +33,7 @@
             {% else %}
                 {% t 'author.multiple-posts', { postCount: postCount } %}
             {% endif %}
-            <span class="bull">
+            <span class="bull" data-test-label="bullet">
                 &bull;
             </span>
         </div>

--- a/src/_includes/partials/author-info.njk
+++ b/src/_includes/partials/author-info.njk
@@ -19,11 +19,11 @@
     <div class="author-meta">
         {% if author.location %}
             <div class="author-location">
-                {{ author.location }} 
+                {{ author.location }}
+                <span class="bull">
+                    &bull;
+                </span>
             </div>
-            <span class="bull">
-                &bull;
-            </span>
         {% endif %}
         <div class="author-stats" data-test-label="author-post-count">
             {% if postCount === 0 %}
@@ -33,10 +33,10 @@
             {% else %}
                 {% t 'author.multiple-posts', { postCount: postCount } %}
             {% endif %}
+            <span class="bull">
+                &bull;
+            </span>
         </div>
-        <span class="bull">
-            &bull;
-        </span>
         {% if author.website %}
             <a
                 class="social-link social-link-wb"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This should revert some of the changes I made while translating the original template files into Nunjucks.

The fix is to move the bullet marks (`span.bull`) back into the `div.author-location` and `div.author-stats` elements, allowing us to hide them properly on mobile devices.

This is the current view on screens < 500 pixels wide:

![image](https://user-images.githubusercontent.com/2051070/152929618-969480c4-8c79-4664-90b1-bd29b2abade5.png)

And here it is after the fix:

![image](https://user-images.githubusercontent.com/2051070/152929785-cd883b0b-1d12-4ecf-abea-85b111b245d1.png)