### PR TITLE
fix: RSS feeds

### DIFF
--- a/cypress/fixtures/common-expected-meta.json
+++ b/cypress/fixtures/common-expected-meta.json
@@ -9,6 +9,7 @@
     "width": 1920,
     "height": 1080
   },
+  "faviconUrl": "https://cdn.freecodecamp.org/universal/favicons/favicon.ico",
   "generator": "Eleventy",
   "facebook": {
     "url": "https://www.facebook.com/freecodecamp"

--- a/cypress/integration/english/author/rss.spec.js
+++ b/cypress/integration/english/author/rss.spec.js
@@ -1,78 +1,86 @@
+const { decodeHTML, XMLToDOM } = require("../../../support/utils/rss");
 const commonExpectedMeta = require("../../../fixtures/common-expected-meta.json");
 const expectedAuthorTitle = `Quincy Larson - ${commonExpectedMeta.siteName}`;
+const feedPath = "/author/quincylarson/rss.xml";
 
 describe("Author page RSS feed", () => {
-  let feed;
+  it("should have the channel title <![CDATA[ Quincy Larson - freeCodeCamp.org ]]>", () => {
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelTitle = feed.querySelector("channel title").innerHTML.trim();
 
-  // To do: add this as a Cypress plugin in separate PR
-  function htmlDecode(input) {
-    const doc = new DOMParser().parseFromString(input, "text/html");
-    return doc.documentElement.textContent;
-  }
-
-  before(async () => {
-    // To do: add this as a Cypress plugin in separate PR
-    const parser = new DOMParser();
-    const res = await cy.request("/author/quincylarson/rss.xml");
-    feed = parser.parseFromString(res.body, "application/xml");
-  });
-
-  it(`should have the channel title <![CDATA[ ${expectedAuthorTitle} ]]>`, () => {
-    const title = feed.querySelector("channel title").innerHTML.trim();
-
-    expect(title).to.equal(`<![CDATA[ ${expectedAuthorTitle} ]]>`);
+      expect(channelTitle).to.equal(`<![CDATA[ ${expectedAuthorTitle} ]]>`);
+    });
   });
 
   it(`should have the channel description <![CDATA[ ${commonExpectedMeta.description} ]]>`, () => {
-    const channelDescription = feed
-      .querySelector("channel description")
-      .innerHTML.trim();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelDescription = feed
+        .querySelector("channel description")
+        .innerHTML.trim();
 
-    expect(channelDescription).to.equal(
-      `<![CDATA[ ${commonExpectedMeta.description} ]]>`
-    );
+      expect(channelDescription).to.equal(
+        `<![CDATA[ ${commonExpectedMeta.description} ]]>`
+      );
+    });
   });
 
-  it(`should have the channel link ${commonExpectedMeta.siteUrl}`, () => {
-    const channelLink = feed.querySelector("channel link").innerHTML.trim();
+  it("should have the channel link http://localhost:8080/news/", () => {
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelLink = feed.querySelector("channel link").innerHTML.trim();
 
-    expect(channelLink).to.equal(`${commonExpectedMeta.siteUrl}`);
+      expect(channelLink).to.equal(`${commonExpectedMeta.siteUrl}`);
+    });
   });
 
   it("should have the expected channel image elements and values", () => {
-    const channelImageURL = feed
-      .querySelector("channel image url")
-      .innerHTML.trim();
-    const channelImageTitle = htmlDecode(
-      feed.querySelector("channel image title").innerHTML.trim()
-    );
-    const channelImageLink = feed
-      .querySelector("channel image link")
-      .innerHTML.trim();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelImageURL = feed
+        .querySelector("channel image url")
+        .innerHTML.trim();
+      const channelImageTitle = decodeHTML(
+        feed.querySelector("channel image title").innerHTML.trim()
+      );
+      const channelImageLink = feed
+        .querySelector("channel image link")
+        .innerHTML.trim();
 
-    expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
-    expect(channelImageTitle).to.equal(expectedAuthorTitle);
-    expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
+      expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
+      expect(channelImageTitle).to.equal(expectedAuthorTitle);
+      expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
+    });
   });
 
   it("should have a channel lastBuildDate that's less than or equal to the current date", () => {
-    const lastBuildDate = new Date(
-      feed.querySelector("channel lastBuildDate").innerHTML.trim()
-    );
-    const currDate = new Date();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const lastBuildDate = new Date(
+        feed.querySelector("channel lastBuildDate").innerHTML.trim()
+      );
+      const currDate = new Date();
 
-    expect(lastBuildDate).to.be.lte(currDate);
+      expect(lastBuildDate).to.be.lte(currDate);
+    });
   });
 
   it("should have a channel ttl set to 60", () => {
-    const channelTTL = feed.querySelector("channel ttl").innerHTML.trim();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelTTL = feed.querySelector("channel ttl").innerHTML.trim();
 
-    expect(channelTTL).to.equal("60");
+      expect(channelTTL).to.equal("60");
+    });
   });
 
   it("should return 15 articles", () => {
-    const articles = feed.querySelectorAll("item");
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const articles = feed.querySelectorAll("item");
 
-    expect([...articles]).to.have.lengthOf(15);
+      expect([...articles]).to.have.lengthOf(15);
+    });
   });
 });

--- a/cypress/integration/english/author/rss.spec.js
+++ b/cypress/integration/english/author/rss.spec.js
@@ -1,19 +1,73 @@
+const commonExpectedMeta = require("../../../fixtures/common-expected-meta.json");
+const expectedAuthorTitle = `Quincy Larson - ${commonExpectedMeta.siteName}`;
+
 describe("Author page RSS feed", () => {
   let feed;
 
+  // To do: add this as a Cypress plugin in separate PR
+  function htmlDecode(input) {
+    const doc = new DOMParser().parseFromString(input, "text/html");
+    return doc.documentElement.textContent;
+  }
+
   before(async () => {
-    // To do: improve RSS tests by using an actual XML parser to
-    // select and test specific fields (titles, descriptions,
-    // timestamps, etc.)
+    // To do: add this as a Cypress plugin in separate PR
     const parser = new DOMParser();
     const res = await cy.request("/author/quincylarson/rss.xml");
     feed = parser.parseFromString(res.body, "application/xml");
   });
 
-  it("should start with the title <![CDATA[ freeCodeCamp.org ]]>", () => {
+  it(`should have the channel title <![CDATA[ ${expectedAuthorTitle} ]]>`, () => {
     const title = feed.querySelector("channel title").innerHTML.trim();
 
-    expect(title).to.equal("<![CDATA[ freeCodeCamp.org ]]>");
+    expect(title).to.equal(`<![CDATA[ ${expectedAuthorTitle} ]]>`);
+  });
+
+  it(`should have the channel description <![CDATA[ ${commonExpectedMeta.description} ]]>`, () => {
+    const channelDescription = feed
+      .querySelector("channel description")
+      .innerHTML.trim();
+
+    expect(channelDescription).to.equal(
+      `<![CDATA[ ${commonExpectedMeta.description} ]]>`
+    );
+  });
+
+  it(`should have the channel link ${commonExpectedMeta.siteUrl}`, () => {
+    const channelLink = feed.querySelector("channel link").innerHTML.trim();
+
+    expect(channelLink).to.equal(`${commonExpectedMeta.siteUrl}`);
+  });
+
+  it("should have the expected channel image elements and values", () => {
+    const channelImageURL = feed
+      .querySelector("channel image url")
+      .innerHTML.trim();
+    const channelImageTitle = htmlDecode(
+      feed.querySelector("channel image title").innerHTML.trim()
+    );
+    const channelImageLink = feed
+      .querySelector("channel image link")
+      .innerHTML.trim();
+
+    expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
+    expect(channelImageTitle).to.equal(expectedAuthorTitle);
+    expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
+  });
+
+  it("should have a channel lastBuildDate that's less than or equal to the current date", () => {
+    const lastBuildDate = new Date(
+      feed.querySelector("channel lastBuildDate").innerHTML.trim()
+    );
+    const currDate = new Date();
+
+    expect(lastBuildDate).to.be.lte(currDate);
+  });
+
+  it("should have a channel ttl set to 60", () => {
+    const channelTTL = feed.querySelector("channel ttl").innerHTML.trim();
+
+    expect(channelTTL).to.equal("60");
   });
 
   it("should return 15 articles", () => {

--- a/cypress/integration/english/landing/rss.spec.js
+++ b/cypress/integration/english/landing/rss.spec.js
@@ -1,79 +1,87 @@
+const { decodeHTML, XMLToDOM } = require("../../../support/utils/rss");
 const commonExpectedMeta = require("../../../fixtures/common-expected-meta.json");
+const feedPath = "/rss.xml";
 
-describe("Landing RSS feed", () => {
-  let feed;
+describe("Landing RSS feed", async () => {
+  it("should have the channel title <![CDATA[ freeCodeCamp.org ]]>", () => {
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelTitle = feed.querySelector("channel title").innerHTML.trim();
 
-  // To do: add this as a Cypress plugin in separate PR
-  function htmlDecode(input) {
-    const doc = new DOMParser().parseFromString(input, "text/html");
-    return doc.documentElement.textContent;
-  }
-
-  before(async () => {
-    // To do: add this as a Cypress plugin in separate PR
-    const parser = new DOMParser();
-    const res = await cy.request("/rss.xml");
-    feed = parser.parseFromString(res.body, "application/xml");
-  });
-
-  it(`should have the channel title <![CDATA[ ${commonExpectedMeta.siteName} ]]>`, () => {
-    const channelTitle = feed.querySelector("channel title").innerHTML.trim();
-
-    expect(channelTitle).to.equal(
-      `<![CDATA[ ${commonExpectedMeta.siteName} ]]>`
-    );
+      expect(channelTitle).to.equal(
+        `<![CDATA[ ${commonExpectedMeta.siteName} ]]>`
+      );
+    });
   });
 
   it(`should have the channel description <![CDATA[ ${commonExpectedMeta.description} ]]>`, () => {
-    const channelDescription = feed
-      .querySelector("channel description")
-      .innerHTML.trim();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelDescription = feed
+        .querySelector("channel description")
+        .innerHTML.trim();
 
-    expect(channelDescription).to.equal(
-      `<![CDATA[ ${commonExpectedMeta.description} ]]>`
-    );
+      expect(channelDescription).to.equal(
+        `<![CDATA[ ${commonExpectedMeta.description} ]]>`
+      );
+    });
   });
 
-  it(`should have the channel link ${commonExpectedMeta.siteUrl}`, () => {
-    const channelLink = feed.querySelector("channel link").innerHTML.trim();
+  it("should have the channel link http://localhost:8080/news/", () => {
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelLink = feed.querySelector("channel link").innerHTML.trim();
 
-    expect(channelLink).to.equal(`${commonExpectedMeta.siteUrl}`);
+      expect(channelLink).to.equal(`${commonExpectedMeta.siteUrl}`);
+    });
   });
 
   it("should have the expected channel image elements and values", () => {
-    const channelImageURL = feed
-      .querySelector("channel image url")
-      .innerHTML.trim();
-    const channelImageTitle = htmlDecode(
-      feed.querySelector("channel image title").innerHTML.trim()
-    );
-    const channelImageLink = feed
-      .querySelector("channel image link")
-      .innerHTML.trim();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelImageURL = feed
+        .querySelector("channel image url")
+        .innerHTML.trim();
+      const channelImageTitle = decodeHTML(
+        feed.querySelector("channel image title").innerHTML.trim()
+      );
+      const channelImageLink = feed
+        .querySelector("channel image link")
+        .innerHTML.trim();
 
-    expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
-    expect(channelImageTitle).to.equal(commonExpectedMeta.title);
-    expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
+      expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
+      expect(channelImageTitle).to.equal(commonExpectedMeta.title);
+      expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
+    });
   });
 
   it("should have a channel lastBuildDate that's less than or equal to the current date", () => {
-    const lastBuildDate = new Date(
-      feed.querySelector("channel lastBuildDate").innerHTML.trim()
-    );
-    const currDate = new Date();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const lastBuildDate = new Date(
+        feed.querySelector("channel lastBuildDate").innerHTML.trim()
+      );
+      const currDate = new Date();
 
-    expect(lastBuildDate).to.be.lte(currDate);
+      expect(lastBuildDate).to.be.lte(currDate);
+    });
   });
 
   it("should have a channel ttl set to 60", () => {
-    const channelTTL = feed.querySelector("channel ttl").innerHTML.trim();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelTTL = feed.querySelector("channel ttl").innerHTML.trim();
 
-    expect(channelTTL).to.equal("60");
+      expect(channelTTL).to.equal("60");
+    });
   });
 
   it("should return 10 articles", () => {
-    const articles = feed.querySelectorAll("item");
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const articles = feed.querySelectorAll("item");
 
-    expect([...articles]).to.have.lengthOf(10);
+      expect([...articles]).to.have.lengthOf(10);
+    });
   });
 });

--- a/cypress/integration/english/landing/rss.spec.js
+++ b/cypress/integration/english/landing/rss.spec.js
@@ -1,19 +1,74 @@
+const commonExpectedMeta = require("../../../fixtures/common-expected-meta.json");
+
 describe("Landing RSS feed", () => {
   let feed;
 
+  // To do: add this as a Cypress plugin in separate PR
+  function htmlDecode(input) {
+    const doc = new DOMParser().parseFromString(input, "text/html");
+    return doc.documentElement.textContent;
+  }
+
   before(async () => {
-    // To do: improve RSS tests by using an actual XML parser to
-    // select and test specific fields (titles, descriptions,
-    // timestamps, etc.)
+    // To do: add this as a Cypress plugin in separate PR
     const parser = new DOMParser();
     const res = await cy.request("/rss.xml");
     feed = parser.parseFromString(res.body, "application/xml");
   });
 
-  it("should start with the title <![CDATA[ freeCodeCamp.org ]]>", () => {
-    const title = feed.querySelector("channel title").innerHTML.trim();
+  it(`should have the channel title <![CDATA[ ${commonExpectedMeta.siteName} ]]>`, () => {
+    const channelTitle = feed.querySelector("channel title").innerHTML.trim();
 
-    expect(title).to.equal("<![CDATA[ freeCodeCamp.org ]]>");
+    expect(channelTitle).to.equal(
+      `<![CDATA[ ${commonExpectedMeta.siteName} ]]>`
+    );
+  });
+
+  it(`should have the channel description <![CDATA[ ${commonExpectedMeta.description} ]]>`, () => {
+    const channelDescription = feed
+      .querySelector("channel description")
+      .innerHTML.trim();
+
+    expect(channelDescription).to.equal(
+      `<![CDATA[ ${commonExpectedMeta.description} ]]>`
+    );
+  });
+
+  it(`should have the channel link ${commonExpectedMeta.siteUrl}`, () => {
+    const channelLink = feed.querySelector("channel link").innerHTML.trim();
+
+    expect(channelLink).to.equal(`${commonExpectedMeta.siteUrl}`);
+  });
+
+  it("should have the expected channel image elements and values", () => {
+    const channelImageURL = feed
+      .querySelector("channel image url")
+      .innerHTML.trim();
+    const channelImageTitle = htmlDecode(
+      feed.querySelector("channel image title").innerHTML.trim()
+    );
+    const channelImageLink = feed
+      .querySelector("channel image link")
+      .innerHTML.trim();
+
+    expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
+    expect(channelImageTitle).to.equal(commonExpectedMeta.title);
+    expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
+  });
+
+  it("should have a channel lastBuildDate that's less than or equal to the current date", () => {
+    const lastBuildDate = new Date(
+      feed.querySelector("channel lastBuildDate").innerHTML.trim()
+    );
+    const currDate = new Date();
+
+    expect(lastBuildDate).to.be.lte(currDate);
+  });
+
+  it("should have a channel ttl set to 60", () => {
+    const channelTTL = feed.querySelector("channel ttl").innerHTML.trim();
+
+    expect(channelTTL).to.equal("60");
   });
 
   it("should return 10 articles", () => {

--- a/cypress/integration/english/tag/rss.spec.js
+++ b/cypress/integration/english/tag/rss.spec.js
@@ -1,78 +1,86 @@
+const { decodeHTML, XMLToDOM } = require("../../../support/utils/rss");
 const commonExpectedMeta = require("../../../fixtures/common-expected-meta.json");
 const expectedTagTitle = `Community - ${commonExpectedMeta.siteName}`;
+const feedPath = "/tag/community/rss.xml";
 
 describe("Author page RSS feed", () => {
-  let feed;
+  it("should have the channel title <![CDATA[ Community - freeCodeCamp.org ]]>", () => {
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelTitle = feed.querySelector("channel title").innerHTML.trim();
 
-  // To do: add this as a Cypress plugin in separate PR
-  function htmlDecode(input) {
-    const doc = new DOMParser().parseFromString(input, "text/html");
-    return doc.documentElement.textContent;
-  }
-
-  before(async () => {
-    // To do: add this as a Cypress plugin in separate PR
-    const parser = new DOMParser();
-    const res = await cy.request("/tag/community/rss.xml");
-    feed = parser.parseFromString(res.body, "application/xml");
-  });
-
-  it(`should have the channel title <![CDATA[ ${expectedTagTitle} ]]>`, () => {
-    const title = feed.querySelector("channel title").innerHTML.trim();
-
-    expect(title).to.equal(`<![CDATA[ ${expectedTagTitle} ]]>`);
+      expect(channelTitle).to.equal(`<![CDATA[ ${expectedTagTitle} ]]>`);
+    });
   });
 
   it(`should have the channel description <![CDATA[ ${commonExpectedMeta.description} ]]>`, () => {
-    const channelDescription = feed
-      .querySelector("channel description")
-      .innerHTML.trim();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelDescription = feed
+        .querySelector("channel description")
+        .innerHTML.trim();
 
-    expect(channelDescription).to.equal(
-      `<![CDATA[ ${commonExpectedMeta.description} ]]>`
-    );
+      expect(channelDescription).to.equal(
+        `<![CDATA[ ${commonExpectedMeta.description} ]]>`
+      );
+    });
   });
 
-  it(`should have the channel link ${commonExpectedMeta.siteUrl}`, () => {
-    const channelLink = feed.querySelector("channel link").innerHTML.trim();
+  it("should have the channel link http://localhost:8080/news/", () => {
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelLink = feed.querySelector("channel link").innerHTML.trim();
 
-    expect(channelLink).to.equal(`${commonExpectedMeta.siteUrl}`);
+      expect(channelLink).to.equal(`${commonExpectedMeta.siteUrl}`);
+    });
   });
 
   it("should have the expected channel image elements and values", () => {
-    const channelImageURL = feed
-      .querySelector("channel image url")
-      .innerHTML.trim();
-    const channelImageTitle = htmlDecode(
-      feed.querySelector("channel image title").innerHTML.trim()
-    );
-    const channelImageLink = feed
-      .querySelector("channel image link")
-      .innerHTML.trim();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelImageURL = feed
+        .querySelector("channel image url")
+        .innerHTML.trim();
+      const channelImageTitle = decodeHTML(
+        feed.querySelector("channel image title").innerHTML.trim()
+      );
+      const channelImageLink = feed
+        .querySelector("channel image link")
+        .innerHTML.trim();
 
-    expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
-    expect(channelImageTitle).to.equal(expectedTagTitle);
-    expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
+      expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
+      expect(channelImageTitle).to.equal(expectedTagTitle);
+      expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
+    });
   });
 
   it("should have a channel lastBuildDate that's less than or equal to the current date", () => {
-    const lastBuildDate = new Date(
-      feed.querySelector("channel lastBuildDate").innerHTML.trim()
-    );
-    const currDate = new Date();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const lastBuildDate = new Date(
+        feed.querySelector("channel lastBuildDate").innerHTML.trim()
+      );
+      const currDate = new Date();
 
-    expect(lastBuildDate).to.be.lte(currDate);
+      expect(lastBuildDate).to.be.lte(currDate);
+    });
   });
 
   it("should have a channel ttl set to 60", () => {
-    const channelTTL = feed.querySelector("channel ttl").innerHTML.trim();
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const channelTTL = feed.querySelector("channel ttl").innerHTML.trim();
 
-    expect(channelTTL).to.equal("60");
+      expect(channelTTL).to.equal("60");
+    });
   });
 
   it("should return 15 articles", () => {
-    const articles = feed.querySelectorAll("item");
+    cy.request(feedPath).then(async (res) => {
+      const feed = XMLToDOM(res.body);
+      const articles = feed.querySelectorAll("item");
 
-    expect([...articles]).to.have.lengthOf(15);
+      expect([...articles]).to.have.lengthOf(15);
+    });
   });
 });

--- a/cypress/support/utils/rss.js
+++ b/cypress/support/utils/rss.js
@@ -1,0 +1,16 @@
+const XMLToDOM = (xml) => {
+  const parser = new DOMParser();
+
+  return parser.parseFromString(xml, "application/xml");
+};
+
+const decodeHTML = (str) => {
+  const doc = new DOMParser().parseFromString(str, "text/html");
+
+  return doc.documentElement.textContent;
+};
+
+module.exports = {
+  XMLToDOM,
+  decodeHTML,
+};

--- a/src/_includes/layouts/feed.njk
+++ b/src/_includes/layouts/feed.njk
@@ -7,16 +7,16 @@
         <description>
             <![CDATA[ {% t 'meta-tags:description' %} ]]>
         </description>
-        <link>{{ site.url }}</link>
+        <link>{{ site.url + "/" }}</link>
         <image>
             <url>{{ site.icon }}</url>
             {% set metaTitle %}{% t 'meta-tags:title' %}{% endset %}
             <title>{{ (metaTitle | escape) if feed.path === "/" else (feed.name | safe + " - freeCodeCamp.org") }}</title>
-            <link>{{ site.url }}</link>
+            <link>{{ site.url + "/" }}</link>
         </image>
         <generator>Eleventy</generator>
         <lastBuildDate>{% buildDateFormatter site.timezone %}</lastBuildDate>
-        <atom:link href="{{ site.url }}" rel="self" type="application/rss+xml" />
+        <atom:link href="{{ site.url + '/' }}" rel="self" type="application/rss+xml" />
         <ttl>60</ttl>
         {% for post in feed.posts %}
             <item>

--- a/src/_includes/layouts/feed.njk
+++ b/src/_includes/layouts/feed.njk
@@ -14,6 +14,7 @@
             <title>{{ (metaTitle | escape) if feed.path === "/" else (feed.name | safe + " - freeCodeCamp.org") }}</title>
             <link>{{ site.url }}</link>
         </image>
+        <generator>Eleventy</generator>
         <lastBuildDate>{% buildDateFormatter site.timezone %}</lastBuildDate>
         <atom:link href="{{ site.url }}" rel="self" type="application/rss+xml" />
         <ttl>60</ttl>

--- a/src/_includes/layouts/feed.njk
+++ b/src/_includes/layouts/feed.njk
@@ -20,10 +20,10 @@
         {% for post in feed.posts %}
             <item>
                 <title>
-                    <![CDATA[ {% fullEscaper post.title %} ]]>
+                    <![CDATA[ {{ post.title | safe }} ]]>
                 </title>
                 <description>
-                    <![CDATA[ {{ post.excerpt | escape }} ]]>
+                    <![CDATA[ {{ post.excerpt | safe }} ]]>
                 </description>
                 <link>{{ site.url + post.path }}</link>
                 <guid isPermaLink="false">{{ post.comment_id }}</guid>
@@ -36,7 +36,7 @@
                 <pubDate>{% buildDateFormatter site.timezone, post.published_at %}</pubDate>
                 <media:content url="{{ post.feature_image }}" medium="image" />
                 <content:encoded>
-                    <![CDATA[ {{ (post.excerpt | escape) if feed.path === "/" else (post.html | safe) }} ]]>
+                    <![CDATA[ {{ (post.excerpt | safe) if feed.path === "/" else (post.html | safe) }} ]]>
                 </content:encoded>
             </item>
         {% endfor %}

--- a/src/_includes/layouts/feed.njk
+++ b/src/_includes/layouts/feed.njk
@@ -2,7 +2,7 @@
     xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
     <channel>
         <title>
-            <![CDATA[ freeCodeCamp.org ]]>
+            <![CDATA[ {{ "freeCodeCamp.org" if feed.path === "/" else (feed.name | safe + " - freeCodeCamp.org") }} ]]>
         </title>
         <description>
             <![CDATA[ {% t 'meta-tags:description' %} ]]>
@@ -11,7 +11,7 @@
         <image>
             <url>{{ site.icon }}</url>
             {% set metaTitle %}{% t 'meta-tags:title' %}{% endset %}
-            <title>{{ metaTitle | escape }}</title>
+            <title>{{ (metaTitle | escape) if feed.path === "/" else (feed.name | safe + " - freeCodeCamp.org") }}</title>
             <link>{{ site.url }}</link>
         </image>
         <lastBuildDate>{% buildDateFormatter site.timezone %}</lastBuildDate>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR removes unnecessary encoding from some of the XML elements in the RSS feeds. The titles, description, and content text are wrapped in `<![CDATA[ ]]>`, so they don't need extra escaping. This may fix the encoding errors on Feedly for some post titles that include an en or em dash:

![image](https://user-images.githubusercontent.com/2051070/153341205-e42ba726-2117-4746-a467-bf20df94dc14.png)

This PR also fixes some other issues on the tag and author feeds, which should include the author or tag name, respectively.

Finally, there are some Cypress tests for the main, author, and tag feeds.