### PR TITLE
fix: set default dimensions and layouts for AMP videos and iframes

### DIFF
--- a/utils/ghost/amp-handler.js
+++ b/utils/ghost/amp-handler.js
@@ -65,11 +65,9 @@ const ampHandler = async (obj) => {
   const setDefaultDimensions = (ampEl) => {
     const width = ampEl.getAttribute("width");
     const height = ampEl.getAttribute("height");
-    const layout = ampEl.getAttribute("layout");
 
     if (!width || width.includes("%")) ampEl.setAttribute("width", 600);
     if (!height || height.includes("%")) ampEl.setAttribute("height", 400);
-    if (!layout) ampEl.setAttribute("layout", "responsive");
 
     return ampEl;
   };
@@ -154,6 +152,8 @@ const ampHandler = async (obj) => {
     // Create <amp-video> elements
     videoEls.map((video) => {
       let ampVideo = createAmpAudioOrVideo("amp-video", video);
+      // Make all videos responsive
+      ampVideo.setAttribute("layout", "responsive");
       ampVideo = setDefaultDimensions(ampVideo);
 
       video.replaceWith(ampVideo);

--- a/utils/ghost/amp-handler.js
+++ b/utils/ghost/amp-handler.js
@@ -62,6 +62,18 @@ const ampHandler = async (obj) => {
     return ampEl;
   };
 
+  const setDefaultDimensions = (ampEl) => {
+    const width = ampEl.getAttribute("width");
+    const height = ampEl.getAttribute("height");
+    const layout = ampEl.getAttribute("layout");
+
+    if (!width || width.includes("%")) ampEl.setAttribute("width", 600);
+    if (!height || height.includes("%")) ampEl.setAttribute("height", 400);
+    if (!layout) ampEl.setAttribute("layout", "responsive");
+
+    return ampEl;
+  };
+
   await Promise.all(
     // Create <amp-img> and <amp-anim> elements
     imgEls.map(async (img) => {
@@ -127,15 +139,7 @@ const ampHandler = async (obj) => {
       }
 
       ampEl.setAttribute("frameborder", "0");
-
-      if (
-        !ampEl.getAttribute("width") ||
-        !ampEl.getAttribute("height") ||
-        !ampEl.getAttribute("layout")
-      ) {
-        ampEl.setAttribute("width", ampEl.width ? ampEl.width : 600);
-        ampEl.setAttribute("height", ampEl.height ? ampEl.height : 400);
-      }
+      ampEl = setDefaultDimensions(ampEl);
 
       iframe.replaceWith(ampEl);
     }),
@@ -149,7 +153,8 @@ const ampHandler = async (obj) => {
 
     // Create <amp-video> elements
     videoEls.map((video) => {
-      const ampVideo = createAmpAudioOrVideo("amp-video", video);
+      let ampVideo = createAmpAudioOrVideo("amp-video", video);
+      ampVideo = setDefaultDimensions(ampVideo);
 
       video.replaceWith(ampVideo);
     })


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
We got a Google Search Console error about the AMP page for a [recent article](https://www.freecodecamp.org/news/data-viz-from-thought-to-chart/) saying that the attributes for the `amp-iframe` are invalid.

In the regular version of that article, we set the `width` of the `iframe` to 100%. But `amp-iframe` requires a number, and doesn't work with percentages.

This PR should handle future cases like this where an `iframe` or `video` uses percentages to set width or height. It also sets the `layout` attribute to `responsive` for `amp-video` elements, similar to the way we do for all `amp-iframes`.

Also, these changes don't affect the HTML for the regular article views, only the AMP HTML for AMP pages.