### PR TITLE
fix: add .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Comment out the line below to run Prettier against the files in the final build
+dist/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:code": "eslint . --ext .js --cache",
     "lint:i18n-schema": "node ./i18n/schema-validation.js",
     "lint:pretty": "prettier --check .",
-    "format": "prettier --ignore-path .gitignore --write .",
+    "format": "prettier --write .",
     "prepare": "husky install"
   },
   "repository": {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Addresses https://github.com/freeCodeCamp/news/pull/180 

<!-- Feel free to add any additional description of changes below this line -->
Seems like #177 didn't resolve the issue with the Renovate Bot's EOL handling for the `package-lock.json` file.

These changes better mirror the setup we have in the main repo, and should get Prettier to ignore the `dist/` folder and `package-lock.json` files while linting and formatting.