### PR TITLE
fix: tweet button encoding

### DIFF
--- a/cypress/integration/english/post/i18n.spec.js
+++ b/cypress/integration/english/post/i18n.spec.js
@@ -1,6 +1,7 @@
 const selectors = {
   socialRow: "[data-test-label='social-row']",
-  learnCtaRow: "[data-test-label='learn-cta-row']"
+  learnCtaRow: "[data-test-label='learn-cta-row']",
+  tweetButton: "[data-test-label='tweet-button']"
 };
 
 describe('Post i18n', () => {
@@ -17,7 +18,7 @@ describe('Post i18n', () => {
   it('the social row tweet button does not render its i18n keys', () => {
     cy.visit('/announcing-rust-course-replit-web');
 
-    cy.get(`${selectors.socialRow} a`)
+    cy.get(selectors.tweetButton)
       .should('have.attr', 'onclick')
       .should('not.contain', 'social-row.default-tweet');
   });

--- a/cypress/integration/english/post/post.spec.js
+++ b/cypress/integration/english/post/post.spec.js
@@ -1,4 +1,10 @@
-describe('Post', () => {
+const selectors = {
+  comments: "[data-test-label='comments']",
+  socialRow: "[data-test-label='social-row']",
+  tweetButton: "[data-test-label='tweet-button']",
+};
+
+describe("Post", () => {
   before(() => {
     cy.visit('/announcing-rust-course-replit-web');
   });
@@ -7,5 +13,26 @@ describe('Post', () => {
     cy.contains(
       "We're Building New Courses on Rust and Python + the Replit.web Framework"
     );
+  });
+
+  it("should not display a comments section", () => {
+    cy.get(selectors.comments).should("not.exist");
+  });
+
+  it("should display the social row", () => {
+    cy.get(selectors.socialRow).should("be.visible");
+  });
+
+  it("the tweet button should open a Twitter window with the correct message and dimensions", () => {
+    cy.get(selectors.tweetButton)
+      .invoke("attr", "onclick")
+      .should("include", "window.open")
+      .should(
+        "include",
+        "https://twitter.com/intent/tweet?text=Thank%20you%20%40ossia%20for%20writing%20this%20helpful%20article.%0A%0AWe%27re%20Building%20New%20Courses%20on%20Rust%20and%20Python%20%2B%20the%20Replit.web%20Framework%0A%0Ahttp://localhost:8080/news/announcing-rust-course-replit-web/"
+      )
+      .should("include", "share-twitter")
+      .should("include", "width=550, height=235")
+      .should("include", "return false");
   });
 });

--- a/cypress/integration/english/post/post.spec.js
+++ b/cypress/integration/english/post/post.spec.js
@@ -1,10 +1,10 @@
 const selectors = {
   comments: "[data-test-label='comments']",
   socialRow: "[data-test-label='social-row']",
-  tweetButton: "[data-test-label='tweet-button']",
+  tweetButton: "[data-test-label='tweet-button']"
 };
 
-describe("Post", () => {
+describe('Post', () => {
   before(() => {
     cy.visit('/announcing-rust-course-replit-web');
   });
@@ -15,24 +15,24 @@ describe("Post", () => {
     );
   });
 
-  it("should not display a comments section", () => {
-    cy.get(selectors.comments).should("not.exist");
+  it('should not display a comments section', () => {
+    cy.get(selectors.comments).should('not.exist');
   });
 
-  it("should display the social row", () => {
-    cy.get(selectors.socialRow).should("be.visible");
+  it('should display the social row', () => {
+    cy.get(selectors.socialRow).should('be.visible');
   });
 
-  it("the tweet button should open a Twitter window with the correct message and dimensions", () => {
+  it('the tweet button should open a Twitter window with the correct message and dimensions', () => {
     cy.get(selectors.tweetButton)
-      .invoke("attr", "onclick")
-      .should("include", "window.open")
+      .invoke('attr', 'onclick')
+      .should('include', 'window.open')
       .should(
-        "include",
-        "https://twitter.com/intent/tweet?text=Thank%20you%20%40ossia%20for%20writing%20this%20helpful%20article.%0A%0AWe%27re%20Building%20New%20Courses%20on%20Rust%20and%20Python%20%2B%20the%20Replit.web%20Framework%0A%0Ahttp://localhost:8080/news/announcing-rust-course-replit-web/"
+        'include',
+        'https://twitter.com/intent/tweet?text=Thank%20you%20%40ossia%20for%20writing%20this%20helpful%20article.%0A%0AWe%27re%20Building%20New%20Courses%20on%20Rust%20and%20Python%20%2B%20the%20Replit.web%20Framework%0A%0Ahttp://localhost:8080/news/announcing-rust-course-replit-web/'
       )
-      .should("include", "share-twitter")
-      .should("include", "width=550, height=235")
-      .should("include", "return false");
+      .should('include', 'share-twitter')
+      .should('include', 'width=550, height=235')
+      .should('include', 'return false');
   });
 });

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2295,6 +2295,7 @@ p.footer-donation a:hover {
     margin-bottom: 1.5em;
 } */
 
+button.cta-button,
 a.cta-button {
   width: content;
   text-decoration: none;

--- a/src/_includes/assets/js/social-row.js
+++ b/src/_includes/assets/js/social-row.js
@@ -1,6 +1,6 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const title = '{{ post.title | escape }}'.replace(/&#39;/g, '%27');
-  const twitter = '{{ post.primary_author.twitter }}';
+document.addEventListener("DOMContentLoaded", () => {
+  const title = "{{ post.title | urlencode }}".replace(/&#39;/g, "%27");
+  const twitter = "{{ post.primary_author.twitter }}";
   const url = window.location;
   const thanks =
     `{% t 'social-row.default-tweet', { twitter: post.primary_author.twitter } %}` +

--- a/src/_includes/assets/js/social-row.js
+++ b/src/_includes/assets/js/social-row.js
@@ -2,16 +2,18 @@ document.addEventListener("DOMContentLoaded", () => {
   const title = "{{ post.title | urlencode }}".replace(/&#39;/g, "%27");
   const twitter = "{{ post.primary_author.twitter }}";
   const url = window.location;
-  const thanks =
-    `{% t 'social-row.default-tweet', { twitter: post.primary_author.twitter } %}` +
-    `%0A%0A${title}%0A%0A${url}`;
+  const escapedDefaultTweet =
+    "{% set defaultTweet %}{% t 'social-row.default-tweet', { twitter: post.primary_author.twitter } %}{% endset %}{{ defaultTweet | urlencode }}";
+  const thanks = `${escapedDefaultTweet}%0A%0A${title}%0A%0A${url}`;
   const button = document.getElementById("tweet-btn");
   const twitterIntentStr = twitter
     ? `https://twitter.com/intent/tweet?text=${thanks}`
     : `https://twitter.com/intent/tweet?text=${title}%0A%0A${url}`;
+  const windowOpenStr = `window.open(
+    '${twitterIntentStr}',
+    'share-twitter',
+    'width=550, height=235'
+  ); return false;`;
 
-  button.addEventListener("click", () => {
-    window.open(twitterIntentStr, "share-twitter", "width=550, height=235");
-    return false;
-  });
+  button.setAttribute("onclick", windowOpenStr);
 });

--- a/src/_includes/assets/js/social-row.js
+++ b/src/_includes/assets/js/social-row.js
@@ -1,11 +1,11 @@
-document.addEventListener("DOMContentLoaded", () => {
-  const title = "{{ post.title | urlencode }}".replace(/&#39;/g, "%27");
-  const twitter = "{{ post.primary_author.twitter }}";
+document.addEventListener('DOMContentLoaded', () => {
+  const title = '{{ post.title | urlencode }}'.replace(/&#39;/g, '%27');
+  const twitter = '{{ post.primary_author.twitter }}';
   const url = window.location;
   const escapedDefaultTweet =
     "{% set defaultTweet %}{% t 'social-row.default-tweet', { twitter: post.primary_author.twitter } %}{% endset %}{{ defaultTweet | urlencode }}";
   const thanks = `${escapedDefaultTweet}%0A%0A${title}%0A%0A${url}`;
-  const button = document.getElementById("tweet-btn");
+  const button = document.getElementById('tweet-btn');
   const twitterIntentStr = twitter
     ? `https://twitter.com/intent/tweet?text=${thanks}`
     : `https://twitter.com/intent/tweet?text=${title}%0A%0A${url}`;
@@ -15,5 +15,5 @@ document.addEventListener("DOMContentLoaded", () => {
     'width=550, height=235'
   ); return false;`;
 
-  button.setAttribute("onclick", windowOpenStr);
+  button.setAttribute('onclick', windowOpenStr);
 });

--- a/src/_includes/assets/js/social-row.js
+++ b/src/_includes/assets/js/social-row.js
@@ -5,16 +5,13 @@ document.addEventListener("DOMContentLoaded", () => {
   const thanks =
     `{% t 'social-row.default-tweet', { twitter: post.primary_author.twitter } %}` +
     `%0A%0A${title}%0A%0A${url}`;
-  const button = document.getElementById('tweet-btn');
-  const windowOpenStr = `window.open(
-    '${
-      twitter
-        ? `https://twitter.com/intent/tweet?text=${thanks}`
-        : `https://twitter.com/intent/tweet?text=${title}%0A%0A${url}`
-    }',
-    'share-twitter',
-    'width=550, height=235'
-  ); return false;`;
+  const button = document.getElementById("tweet-btn");
+  const twitterIntentStr = twitter
+    ? `https://twitter.com/intent/tweet?text=${thanks}`
+    : `https://twitter.com/intent/tweet?text=${title}%0A%0A${url}`;
 
-  button.setAttribute('onclick', windowOpenStr);
+  button.addEventListener("click", () => {
+    window.open(twitterIntentStr, "share-twitter", "width=550, height=235");
+    return false;
+  });
 });

--- a/src/_includes/partials/social-row.njk
+++ b/src/_includes/partials/social-row.njk
@@ -2,8 +2,8 @@
 
 <p data-test-label="social-row" class="social-row" data-test-label="social-row">
     {% t i18nSocialRowTwitterKey, {
-        '<0>': '<a id="tweet-btn" class="cta-button">',
-        '</0>': '</a>',
+        '<0>': '<button id="tweet-btn" class="cta-button">',
+        '</0>': '</button>',
         interpolation: {
             escapeValue: false
         }

--- a/src/_includes/partials/social-row.njk
+++ b/src/_includes/partials/social-row.njk
@@ -1,6 +1,6 @@
 {% set i18nSocialRowTwitterKey = 'social-row.author-has-twitter' if post.primary_author.twitter else 'social-row.author-no-twitter' %}
 
-<p data-test-label="social-row" class="social-row" data-test-label="social-row">
+<p data-test-label="social-row" class="social-row">
     {% t i18nSocialRowTwitterKey, {
         '<0>': '<button id="tweet-btn" class="cta-button">',
         '</0>': '</button>',

--- a/src/_includes/partials/social-row.njk
+++ b/src/_includes/partials/social-row.njk
@@ -2,7 +2,7 @@
 
 <p data-test-label="social-row" class="social-row">
     {% t i18nSocialRowTwitterKey, {
-        '<0>': '<button id="tweet-btn" class="cta-button">',
+        '<0>': '<button id="tweet-btn" class="cta-button" data-test-label="tweet-button">',
         '</0>': '</button>',
         interpolation: {
             escapeValue: false


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
These changes should fix encoding issues with certain article titles with special characters.

Here's an example that Abbey sent recently for [this article](https://www.freecodecamp.org/news/for-loop-in-java-foreach-loop-syntax-example/) with a + character in the title:

![thumb-missing em dash twitter card](https://user-images.githubusercontent.com/2051070/154659764-7bd8b09c-6fe7-42c5-9b7d-10c3bb2d0e00.png)

The main issue was that the titles had to be URL encoded to build the Tweet Web Intent URL, not escaped like they are now.

This also changes the tweet button from an anchor element to and actual button for better accessibility.