### PR TITLE
fix: ltr layout for code snippets

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2409,8 +2409,7 @@ a.banner:hover span {
   direction: rtl;
 }
 
-.rtl-layout .post-full-content pre,
-.rtl-layout .post-full-content code {
+.rtl-layout .post-full-content pre {
   direction: ltr;
 }
 

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2409,6 +2409,11 @@ a.banner:hover span {
   direction: rtl;
 }
 
+.rtl-layout .post-full-content pre,
+.rtl-layout .post-full-content code {
+  direction: ltr;
+}
+
 .rtl-layout .author-card .avatar-wrapper,
 .rtl-layout .author-card img.author-profile-image {
   margin: 0 0 0 15px;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This should fix the issue with code blocks and snippets appearing right-to-left on the Arabic publication:

![image](https://user-images.githubusercontent.com/2051070/154637353-a95e750b-ddab-4383-8143-f2ab59cfdeed.png)

There may be a way to do this with the `:not()` pseudo selector in the rule above, but this seems a bit simpler.

Could you take a look at this and make sure we're not missing anything @ahmadabdolsaheb?