### PR TITLE
fix: RSS encoding and image

### DIFF
--- a/cypress/fixtures/common-expected-meta.json
+++ b/cypress/fixtures/common-expected-meta.json
@@ -9,7 +9,10 @@
     "width": 1920,
     "height": 1080
   },
-  "faviconUrl": "https://cdn.freecodecamp.org/universal/favicons/favicon.ico",
+  "favicon": {
+    "ico": "https://cdn.freecodecamp.org/universal/favicons/favicon.ico",
+    "png": "https://cdn.freecodecamp.org/universal/favicons/favicon.png"
+  },
   "generator": "Eleventy",
   "facebook": {
     "url": "https://www.facebook.com/freecodecamp"

--- a/cypress/integration/english/author/rss.spec.js
+++ b/cypress/integration/english/author/rss.spec.js
@@ -4,6 +4,13 @@ const expectedAuthorTitle = `Quincy Larson - ${commonExpectedMeta.siteName}`;
 const feedPath = '/author/quincylarson/rss.xml';
 
 describe('Author page RSS feed', () => {
+  it('should start with a UTF-8 encoding declaration', () => {
+    cy.request(feedPath).then(async res => {
+      expect(res.body.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).to
+        .be.true;
+    });
+  });
+
   it('should have the channel title <![CDATA[ Quincy Larson - freeCodeCamp.org ]]>', () => {
     cy.request(feedPath).then(async res => {
       const feed = XMLToDOM(res.body);
@@ -48,7 +55,7 @@ describe('Author page RSS feed', () => {
         .querySelector('channel image link')
         .innerHTML.trim();
 
-      expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
+      expect(channelImageURL).to.equal(commonExpectedMeta.favicon.png);
       expect(channelImageTitle).to.equal(expectedAuthorTitle);
       expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
     });

--- a/cypress/integration/english/landing/rss.spec.js
+++ b/cypress/integration/english/landing/rss.spec.js
@@ -3,6 +3,13 @@ const commonExpectedMeta = require('../../../fixtures/common-expected-meta.json'
 const feedPath = '/rss.xml';
 
 describe('Landing RSS feed', async () => {
+  it('should start with a UTF-8 encoding declaration', () => {
+    cy.request(feedPath).then(async res => {
+      expect(res.body.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).to
+        .be.true;
+    });
+  });
+
   it('should have the channel title <![CDATA[ freeCodeCamp.org ]]>', () => {
     cy.request(feedPath).then(async res => {
       const feed = XMLToDOM(res.body);
@@ -49,7 +56,7 @@ describe('Landing RSS feed', async () => {
         .querySelector('channel image link')
         .innerHTML.trim();
 
-      expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
+      expect(channelImageURL).to.equal(commonExpectedMeta.favicon.png);
       expect(channelImageTitle).to.equal(commonExpectedMeta.title);
       expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
     });

--- a/cypress/integration/english/tag/rss.spec.js
+++ b/cypress/integration/english/tag/rss.spec.js
@@ -4,6 +4,13 @@ const expectedTagTitle = `Community - ${commonExpectedMeta.siteName}`;
 const feedPath = '/tag/community/rss.xml';
 
 describe('Author page RSS feed', () => {
+  it('should start with a UTF-8 encoding declaration', () => {
+    cy.request(feedPath).then(async res => {
+      expect(res.body.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).to
+        .be.true;
+    });
+  });
+
   it('should have the channel title <![CDATA[ Community - freeCodeCamp.org ]]>', () => {
     cy.request(feedPath).then(async res => {
       const feed = XMLToDOM(res.body);
@@ -48,7 +55,7 @@ describe('Author page RSS feed', () => {
         .querySelector('channel image link')
         .innerHTML.trim();
 
-      expect(channelImageURL).to.equal(commonExpectedMeta.faviconUrl);
+      expect(channelImageURL).to.equal(commonExpectedMeta.favicon.png);
       expect(channelImageTitle).to.equal(expectedTagTitle);
       expect(channelImageLink).to.equal(commonExpectedMeta.siteUrl);
     });

--- a/src/_includes/layouts/feed.njk
+++ b/src/_includes/layouts/feed.njk
@@ -10,7 +10,7 @@
         </description>
         <link>{{ site.url + "/" }}</link>
         <image>
-            <url>{{ site.icon }}</url>
+            <url>https://cdn.freecodecamp.org/universal/favicons/favicon.png</url>
             {% set metaTitle %}{% t 'meta-tags:title' %}{% endset %}
             <title>{{ (metaTitle | escape) if feed.path === "/" else (feed.name | safe + " - freeCodeCamp.org") }}</title>
             <link>{{ site.url + "/" }}</link>

--- a/src/_includes/layouts/feed.njk
+++ b/src/_includes/layouts/feed.njk
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/"
     xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
     <channel>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
There are still some encoding issues with em dashes on Feedly. They may require that incoming RSS feeds have explicit UTF-8 encoding.

This PR adds a UTF-8 encoding declaration to all feeds. It also changes the site image to a PNG version of the favicon, based on suggestions from a feed validator.

This PR should not be merged until https://github.com/freeCodeCamp/cdn/pull/119 is merged.