### PR TITLE
fix: add redirect for frontend development article

### DIFF
--- a/docker-config/languages/english/serve.json
+++ b/docker-config/languages/english/serve.json
@@ -28,6 +28,11 @@
       "destination": "/news/about"
     },
     {
+      "source": "/fullstack-development-project-create-a-blog-with-html-css",
+      "destination": "/news/frontend-development-project-create-a-blog-with-html-css",
+      "type": 302
+    },
+    {
       "source": "/my-open-source-instagram-bot-got-me-2-500-real-followers-for-5-in-server-costs-e40491358340",
       "destination": "/news/building-bots",
       "type": 302


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR adds a redirect for [this article](https://www.freecodecamp.org/news/fullstack-development-project-create-a-blog-with-html-css/), which has already been shared on social media.

The slug hasn't been changed in Ghost yet. With the automated builds, I'm not sure what the best process would be. My thinking is that it's best to get this merged, then change the slug in Ghost to `frontend-development-project-create-a-blog-with-html-css` for the next build, though there may be a better way.