### PR TITLE
fix: ltr code element

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2474,6 +2474,5 @@ a.banner:hover span {
 .rtl-layout .post-full-content p code {
   word-break: normal;
   direction: ltr;
-  white-space: nowrap;
   unicode-bidi: isolate;
 }

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2473,4 +2473,6 @@ a.banner:hover span {
 
 .rtl-layout .post-full-content p code {
   word-break: normal;
+  direction: ltr;
+  unicode-bidi: isolate;
 }

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2474,5 +2474,6 @@ a.banner:hover span {
 .rtl-layout .post-full-content p code {
   word-break: normal;
   direction: ltr;
+  white-space: nowrap;
   unicode-bidi: isolate;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->


<!-- Feel free to add any additional description of changes below this line -->
@islamh-mahfouz, 
Thanks for taking the time and editing the articles.

LTR code elements seems achievable using the following styling:
```
.rtl-layout .post-full-content code {
    word-break: normal;
    direction: ltr;
    unicode-bidi: isolate;
}
```

I would appreciate it if you could try this with a sample of your articles and see if works.



