### PR TITLE
fix(tests): regex for source and destination, duplicate redirects

### DIFF
--- a/docker-config/languages/redirects.test.js
+++ b/docker-config/languages/redirects.test.js
@@ -25,7 +25,7 @@ describe('Redirect and rewrite tests:', () => {
       });
 
       test('redirect sources start with /', () => {
-        redirects.map(redirect => expect(redirect.source[0]).toEqual('/'));
+        redirects.map(redirect => expect(redirect.source).toMatch(/^\//));
       });
 
       test('redirect destinations start with / or https://', () => {
@@ -35,12 +35,12 @@ describe('Redirect and rewrite tests:', () => {
       });
 
       test('redirect sources do not end with /', () => {
-        redirects.map(redirect => expect(redirect.source).not.toMatch(/$\//));
+        redirects.map(redirect => expect(redirect.source).not.toMatch(/\/$/));
       });
 
       test('redirect destinations do not end with /', () => {
         redirects.map(redirect =>
-          expect(redirect.destination).not.toMatch(/$\//)
+          expect(redirect.destination).not.toMatch(/\/$/)
         );
       });
 
@@ -65,15 +65,10 @@ describe('Redirect and rewrite tests:', () => {
       });
 
       test('there are no duplicate redirects', () => {
-        const duplicates = redirects.reduce((acc, curr, i, arr) => {
-          if (arr.indexOf(curr) !== i && acc.indexOf(curr) < 0) {
-            acc.push(curr);
-          }
+        const sources = redirects.map(obj => obj.source);
+        const uniqueSources = [...new Set(sources)];
 
-          return acc;
-        }, []);
-
-        expect(duplicates.length).toEqual(0);
+        expect(sources.length).toEqual(uniqueSources.length);
       });
     });
   });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR has a few fixes and improvements for the redirects tests.

The `redirect sources start with /` test was converted to use regex for better reporting, and will now show the entire source string in event of a failure.

The regex for the `redirect sources do not end with /` and `redirect destinations do not end with /` tests have been updated so they match `/` characters at the end of strings. These weren't being matched before.

Finally, the duplicate redirects test was fixed to actually catch duplicate source strings.