### PR TITLE
fix: boolean attributes for AMP elements

### DIFF
--- a/cypress/integration/english/amp/amp.spec.js
+++ b/cypress/integration/english/amp/amp.spec.js
@@ -20,11 +20,13 @@ const selectors = {
   },
   videos: {
     bigBuckBunny: 'amp-video:nth-child(24)',
-    bigBuckBunnyWithSourceEl: 'amp-video:nth-child(26)'
+    bigBuckBunnyWithSourceEl: 'amp-video:nth-child(26)',
+    bigBuckBunnyWithBooleanAttributes: 'amp-video:nth-child(28)'
   },
   audio: {
-    rideOfTheValkyries: 'amp-audio:nth-child(29)',
-    rideOfTheValkyriesWithSourceEl: 'amp-audio:nth-child(31)'
+    rideOfTheValkyries: 'amp-audio:nth-child(31)',
+    rideOfTheValkyriesWithSourceEl: 'amp-audio:nth-child(33)',
+    rideOfTheValkyriesWithBooleanAttributes: 'amp-audio:nth-child(35)'
   }
 };
 
@@ -220,6 +222,17 @@ describe('AMP page', () => {
         }
       );
     });
+
+    it('the third video should have the `loop` and `autoplay` boolean attributes without any values', () => {
+      cy.get(selectors.videos.bigBuckBunnyWithBooleanAttributes).then($el => {
+        expect($el.attr('loop')).to.exist;
+        expect($el.attr('autoplay')).to.exist;
+        // With jQuery's `.attr()` method, the value for properly set boolean attributes
+        // will be the same as the attribute name itself
+        expect($el.attr('loop')).to.equal('loop');
+        expect($el.attr('autoplay')).to.equal('autoplay');
+      });
+    });
   });
 
   context('<amp-audio>', () => {
@@ -253,6 +266,22 @@ describe('AMP page', () => {
           expect($el.attr('src')).to.equal(
             'https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3'
           );
+        }
+      );
+    });
+
+    it('the third audio element should have the `loop`, `muted`, and `autoplay` boolean attributes without any values', () => {
+      cy.get(selectors.audio.rideOfTheValkyriesWithBooleanAttributes).then(
+        $el => {
+          expect($el.attr('loop')).to.exist;
+          expect($el.attr('autoplay')).to.exist;
+          expect($el.attr('muted')).to.exist;
+          // With jQuery's `.attr()` method, the value for properly set boolean attributes
+          // will be the same as the attribute name itself, with the exception of `muted`, which
+          // defaults to an empty string
+          expect($el.attr('loop')).to.equal('loop');
+          expect($el.attr('autoplay')).to.equal('autoplay');
+          expect($el.attr('muted')).to.equal('');
         }
       );
     });

--- a/cypress/integration/english/amp/amp.spec.js
+++ b/cypress/integration/english/amp/amp.spec.js
@@ -3,8 +3,8 @@ const {
 } = require('../../../../utils/transforms/html-sanitizer');
 
 const selectors = {
-  siteLogo: '.logo > .i-amphtml-element',
   images: {
+    siteLogo: '.logo > .i-amphtml-element',
     cats: ':nth-child(3) > .i-amphtml-element',
     catsWithCaption: ':nth-child(5) > .i-amphtml-element',
     smallIcon: ':nth-child(7) > .i-amphtml-element'
@@ -35,6 +35,17 @@ const stripAutoAMPAttributes = attrArr =>
     attr => !['class', 'style'].includes(attr) && !attr.startsWith('i-amphtml')
   );
 
+const testAllowedAttributes = (type, selector) => {
+  cy.get(selector).then($el => {
+    const attributes = stripAutoAMPAttributes($el[0].getAttributeNames());
+    const diff = attributes.filter(
+      attr => !allowedAMPAttributes[type].includes(attr)
+    );
+
+    expect(diff).to.have.length(0);
+  });
+};
+
 describe('AMP page', () => {
   before(() => {
     cy.visit('/amp-page-tests/amp');
@@ -50,7 +61,7 @@ describe('AMP page', () => {
 
   context('<amp-img>', () => {
     it('should render the site logo as an amp-img', () => {
-      cy.get(selectors.siteLogo).then($el => {
+      cy.get(selectors.images.siteLogo).then($el => {
         expect($el[0].tagName).to.equal('AMP-IMG');
       });
     });
@@ -61,17 +72,6 @@ describe('AMP page', () => {
         expect($el.attr('height')).to.equal('222');
         expect($el.attr('alt')).to.equal('cats');
         expect($el.attr('layout')).to.equal('responsive');
-      });
-    });
-
-    it('the first image of cats should only contain allowed amp-img attributes', () => {
-      cy.get(selectors.images.cats).then($el => {
-        const attributes = stripAutoAMPAttributes($el[0].getAttributeNames());
-        const diff = attributes.filter(
-          attr => !allowedAMPAttributes['amp-img'].includes(attr)
-        );
-
-        expect(diff).to.have.length(0);
       });
     });
 
@@ -86,6 +86,14 @@ describe('AMP page', () => {
         expect($el.attr('layout')).to.equal('fixed');
       });
     });
+
+    it('all amp-img elements should only contain the allowed attributes', () => {
+      const AMPImgSelectors = [...Object.values(selectors.images)];
+
+      AMPImgSelectors.forEach(selector =>
+        testAllowedAttributes('amp-img', selector)
+      );
+    });
   });
 
   context('<amp-anim>', () => {
@@ -98,21 +106,18 @@ describe('AMP page', () => {
       });
     });
 
-    it('the first typing cat gif should only contain allowed amp-anim attributes', () => {
-      cy.get(selectors.gifs.typingCat).then($el => {
-        const attributes = stripAutoAMPAttributes($el[0].getAttributeNames());
-        const diff = attributes.filter(
-          attr => !allowedAMPAttributes['amp-anim'].includes(attr)
-        );
-
-        expect(diff).to.have.length(0);
-      });
-    });
-
     it('the second typing cat gif should have a figcaption with the expected text', () => {
       cy.get(selectors.gifs.typingCatWithCaption)
         .get('figcaption')
         .contains('Tap tap tappity tap');
+    });
+
+    it('all amp-anim elements should only contain the allowed attributes', () => {
+      const AMPAnimSelectors = [...Object.values(selectors.gifs)];
+
+      AMPAnimSelectors.forEach(selector =>
+        testAllowedAttributes('amp-anim', selector)
+      );
     });
   });
 
@@ -126,15 +131,8 @@ describe('AMP page', () => {
       });
     });
 
-    it('should only contain allowed amp-youtube attributes', () => {
-      cy.get(selectors.youtube).then($el => {
-        const attributes = stripAutoAMPAttributes($el[0].getAttributeNames());
-        const diff = attributes.filter(
-          attr => !allowedAMPAttributes['amp-youtube'].includes(attr)
-        );
-
-        expect(diff).to.have.length(0);
-      });
+    it('the amp-youtube element should only contain the allowed attributes', () => {
+      testAllowedAttributes('amp-youtube', selectors.youtube);
     });
   });
 
@@ -144,17 +142,6 @@ describe('AMP page', () => {
         expect($el.attr('width')).to.equal('384');
         expect($el.attr('height')).to.equal('480');
         expect($el.attr('frameborder')).to.equal('0');
-      });
-    });
-
-    it('the GIPHY iframe should only contain allowed amp-iframe attributes', () => {
-      cy.get(selectors.iframes.giphy).then($el => {
-        const attributes = stripAutoAMPAttributes($el[0].getAttributeNames());
-        const diff = attributes.filter(
-          attr => !allowedAMPAttributes['amp-iframe'].includes(attr)
-        );
-
-        expect(diff).to.have.length(0);
       });
     });
 
@@ -170,15 +157,12 @@ describe('AMP page', () => {
       });
     });
 
-    it('the CodePen iframe should only contain allowed amp-iframe attributes', () => {
-      cy.get(selectors.iframes.codePen).then($el => {
-        const attributes = stripAutoAMPAttributes($el[0].getAttributeNames());
-        const diff = attributes.filter(
-          attr => !allowedAMPAttributes['amp-iframe'].includes(attr)
-        );
+    it('all amp-iframe elements should only contain the allowed attributes', () => {
+      const AMPIframeSelectors = [...Object.values(selectors.iframes)];
 
-        expect(diff).to.have.length(0);
-      });
+      AMPIframeSelectors.forEach(selector =>
+        testAllowedAttributes('amp-iframe', selector)
+      );
     });
   });
 
@@ -195,17 +179,6 @@ describe('AMP page', () => {
         );
         expect($el.attr('controls')).to.exist;
         expect($el.attr('layout')).to.equal('responsive');
-      });
-    });
-
-    it('the first video should only contain allowed amp-video attributes', () => {
-      cy.get(selectors.videos.bigBuckBunny).then($el => {
-        const attributes = stripAutoAMPAttributes($el[0].getAttributeNames());
-        const diff = attributes.filter(
-          attr => !allowedAMPAttributes['amp-video'].includes(attr)
-        );
-
-        expect(diff).to.have.length(0);
       });
     });
 
@@ -233,6 +206,14 @@ describe('AMP page', () => {
         expect($el.attr('autoplay')).to.equal('autoplay');
       });
     });
+
+    it('all amp-video elements should only contain the allowed attributes', () => {
+      const AMPVideoSelectors = [...Object.values(selectors.videos)];
+
+      AMPVideoSelectors.forEach(selector =>
+        testAllowedAttributes('amp-video', selector)
+      );
+    });
   });
 
   context('<amp-audio>', () => {
@@ -242,17 +223,6 @@ describe('AMP page', () => {
           'https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3'
         );
         expect($el.attr('controls')).to.exist;
-      });
-    });
-
-    it('the first audio element should only contain allowed amp-audio attributes', () => {
-      cy.get(selectors.audio.rideOfTheValkyries).then($el => {
-        const attributes = stripAutoAMPAttributes($el[0].getAttributeNames());
-        const diff = attributes.filter(
-          attr => !allowedAMPAttributes['amp-audio'].includes(attr)
-        );
-
-        expect(diff).to.have.length(0);
       });
     });
 
@@ -283,6 +253,14 @@ describe('AMP page', () => {
           expect($el.attr('autoplay')).to.equal('autoplay');
           expect($el.attr('muted')).to.equal('');
         }
+      );
+    });
+
+    it('all amp-audio elements should only contain the allowed attributes', () => {
+      const AMPAudioSelectors = [...Object.values(selectors.audio)];
+
+      AMPAudioSelectors.forEach(selector =>
+        testAllowedAttributes('amp-audio', selector)
       );
     });
   });

--- a/utils/ghost/generate-amp-obj.js
+++ b/utils/ghost/generate-amp-obj.js
@@ -29,17 +29,21 @@ const generateAMPObj = async obj => {
   const videoEls = [...document.getElementsByTagName('video')];
 
   const setAllowedAttributes = (allowedAttributesArr, originalEl, ampEl) => {
-    allowedAttributesArr.forEach(attribute => {
+    allowedAttributesArr.forEach(attributeName => {
       const booleanAttributes = ['loop', 'autoplay', 'muted'];
 
-      if (originalEl.hasAttribute(attribute)) {
+      if (originalEl.hasAttribute(attributeName)) {
         // Add boolean attribute to the ampEl so it is present,
         // but prevent it from being set to "true"
-        if (booleanAttributes.includes(attribute)) {
-          return ampEl.setAttribute(attribute, '');
+        if (booleanAttributes.includes(attributeName)) {
+          return ampEl.setAttribute(attributeName, '');
         }
 
-        return ampEl.setAttribute(attribute, originalEl[attribute]);
+        // Set allowed attribute to the value from the original element
+        return ampEl.setAttribute(
+          attributeName,
+          originalEl.getAttribute(attributeName)
+        );
       }
     });
 
@@ -79,84 +83,84 @@ const generateAMPObj = async obj => {
   };
 
   await Promise.all(
-    imgEls.map(async img => {
-      const width = img.getAttribute('width');
+    imgEls.map(async imgEl => {
+      const width = imgEl.getAttribute('width');
       // Special handling for small image and gif sizes
       const layoutType = width < 300 ? 'fixed' : 'responsive';
 
       // Create <amp-img> elements
-      if (extname(img.src).toLowerCase() !== '.gif') {
-        let ampImg = document.createElement('amp-img');
+      if (extname(imgEl.src).toLowerCase() !== '.gif') {
+        let ampImgEl = document.createElement('amp-img');
 
-        ampImg = setAllowedAttributes(
+        ampImgEl = setAllowedAttributes(
           allowedAMPAttributes['amp-img'],
-          img,
-          ampImg
+          imgEl,
+          ampImgEl
         );
-        ampImg.setAttribute('layout', layoutType);
+        ampImgEl.setAttribute('layout', layoutType);
 
         // Set element type for dynamically loading scripts in template
         ampObj.elements['amp-img'] = true;
 
-        img.replaceWith(ampImg);
+        imgEl.replaceWith(ampImgEl);
       } else {
         // Create <amp-anim> elements
-        let ampAnim = document.createElement('amp-anim');
+        let ampAnimEl = document.createElement('amp-anim');
 
-        ampAnim = setAllowedAttributes(
+        ampAnimEl = setAllowedAttributes(
           allowedAMPAttributes['amp-anim'],
-          img,
-          ampAnim
+          imgEl,
+          ampAnimEl
         );
-        ampAnim.setAttribute('layout', layoutType);
+        ampAnimEl.setAttribute('layout', layoutType);
 
         // Set element type for dynamically loading scripts in template
         ampObj.elements['amp-anim'] = true;
 
-        img.replaceWith(ampAnim);
+        imgEl.replaceWith(ampAnimEl);
       }
     }),
 
-    iframeEls.map(iframe => {
+    iframeEls.map(iframeEl => {
       // This code is based heavily on the implementation
       // here: https://github.com/jbhannah/amperize
-      const youtubeRe = iframe.src.match(
+      const youtubeRe = iframeEl.src.match(
         /^.*(youtu.be\/|youtube(-nocookie)?.com\/(v\/|.*u\/\w\/|embed\/|.*v=))([\w-]{11}).*/
       );
       // Set width and height for all iframes, and use defaults if necessary
-      iframe = setWidthAndHeight(iframe);
+      iframeEl = setWidthAndHeight(iframeEl);
 
       // Create <amp-youtube> elements
       if (youtubeRe) {
-        let ampYouTube = document.createElement('amp-youtube');
+        let ampYouTubeEl = document.createElement('amp-youtube');
 
-        ampYouTube = setAllowedAttributes(
+        ampYouTubeEl = setAllowedAttributes(
           allowedAMPAttributes['amp-youtube'],
-          iframe,
-          ampYouTube
+          iframeEl,
+          ampYouTubeEl
         );
-        ampYouTube.setAttribute('layout', 'responsive');
-        ampYouTube.setAttribute('data-videoid', youtubeRe[4]);
+        ampYouTubeEl.setAttribute('layout', 'responsive');
+        ampYouTubeEl.setAttribute('data-videoid', youtubeRe[4]);
 
         // Set element type for dynamically loading scripts in template
         ampObj.elements['amp-youtube'] = true;
 
-        iframe.replaceWith(ampYouTube);
+        iframeEl.replaceWith(ampYouTubeEl);
       } else {
         // Create <amp-iframe> elements
-        let ampIframe = document.createElement('amp-iframe');
+        let ampIframeEl = document.createElement('amp-iframe');
 
-        ampIframe = setAllowedAttributes(
+        ampIframeEl = setAllowedAttributes(
           allowedAMPAttributes['amp-iframe'],
-          iframe,
-          ampIframe
+          iframeEl,
+          ampIframeEl
         );
-        ampIframe.setAttribute('layout', 'responsive');
+        ampIframeEl.setAttribute('layout', 'responsive');
 
         // Special handling for the sandbox attribute
-        ampIframe.sandbox
-          ? ampIframe.sandbox
-          : ampIframe.setAttribute(
+        ampIframeEl.sandbox
+          ? ampIframeEl.sandbox
+          : ampIframeEl.setAttribute(
               'sandbox',
               'allow-scripts allow-same-origin allow-popups'
             );
@@ -164,56 +168,56 @@ const generateAMPObj = async obj => {
         // Set element type for dynamically loading scripts in template
         ampObj.elements['amp-iframe'] = true;
 
-        iframe.replaceWith(ampIframe);
+        iframeEl.replaceWith(ampIframeEl);
       }
     }),
 
     // Create <amp-audio> elements
-    audioEls.map(audio => {
-      const sourceEls = [...audio.getElementsByTagName('source')];
-      let ampAudio = document.createElement('amp-audio');
+    audioEls.map(audioEl => {
+      const sourceEls = [...audioEl.getElementsByTagName('source')];
+      let ampAudioEl = document.createElement('amp-audio');
 
-      ampAudio = setAllowedAttributes(
+      ampAudioEl = setAllowedAttributes(
         allowedAMPAttributes['amp-audio'],
-        audio,
-        ampAudio
+        audioEl,
+        ampAudioEl
       );
 
       // Add source elements as children
-      sourceEls.forEach(source => ampAudio.appendChild(source));
-      ampAudio = addFallback(ampAudio);
+      sourceEls.forEach(source => ampAudioEl.appendChild(source));
+      ampAudioEl = addFallback(ampAudioEl);
 
       // Set element type for dynamically loading scripts in template
       ampObj.elements['amp-audio'] = true;
 
-      audio.replaceWith(ampAudio);
+      audioEl.replaceWith(ampAudioEl);
     }),
 
     // Create <amp-video> elements
-    videoEls.map(video => {
+    videoEls.map(videoEl => {
       // Set width and height for all videos, and use defaults if necessary
-      video = setWidthAndHeight(video);
+      videoEl = setWidthAndHeight(videoEl);
 
-      const sourceEls = [...video.getElementsByTagName('source')];
-      let ampVideo = document.createElement('amp-video');
+      const sourceEls = [...videoEl.getElementsByTagName('source')];
+      let ampVideoEl = document.createElement('amp-video');
 
-      ampVideo = setAllowedAttributes(
+      ampVideoEl = setAllowedAttributes(
         allowedAMPAttributes['amp-video'],
-        video,
-        ampVideo
+        videoEl,
+        ampVideoEl
       );
-      ampVideo.setAttribute('layout', 'responsive');
+      ampVideoEl.setAttribute('layout', 'responsive');
       // Ensure controls are set
-      ampVideo.setAttribute('controls', '');
+      ampVideoEl.setAttribute('controls', '');
 
       // Add source elements as children
-      sourceEls.forEach(source => ampVideo.appendChild(source));
-      ampVideo = addFallback(ampVideo);
+      sourceEls.forEach(source => ampVideoEl.appendChild(source));
+      ampVideoEl = addFallback(ampVideoEl);
 
       // Set element type for dynamically loading scripts in template
       ampObj.elements['amp-video'] = true;
 
-      video.replaceWith(ampVideo);
+      videoEl.replaceWith(ampVideoEl);
     })
   );
 

--- a/utils/ghost/generate-amp-obj.js
+++ b/utils/ghost/generate-amp-obj.js
@@ -28,8 +28,10 @@ const generateAMPObj = async obj => {
   const audioEls = [...document.getElementsByTagName('audio')];
   const videoEls = [...document.getElementsByTagName('video')];
 
-  const setAllowedAttributes = (allowedAttributesArr, originalEl, ampEl) => {
-    allowedAttributesArr.forEach(attributeName => {
+  const setAllowedAttributes = (type, originalEl, ampEl) => {
+    const allowedAttributes = allowedAMPAttributes[type];
+
+    allowedAttributes.forEach(attributeName => {
       const booleanAttributes = ['loop', 'autoplay', 'muted'];
 
       if (originalEl.hasAttribute(attributeName)) {
@@ -92,11 +94,7 @@ const generateAMPObj = async obj => {
       if (extname(imgEl.src).toLowerCase() !== '.gif') {
         let ampImgEl = document.createElement('amp-img');
 
-        ampImgEl = setAllowedAttributes(
-          allowedAMPAttributes['amp-img'],
-          imgEl,
-          ampImgEl
-        );
+        ampImgEl = setAllowedAttributes('amp-img', imgEl, ampImgEl);
         ampImgEl.setAttribute('layout', layoutType);
 
         // Set element type for dynamically loading scripts in template
@@ -107,11 +105,7 @@ const generateAMPObj = async obj => {
         // Create <amp-anim> elements
         let ampAnimEl = document.createElement('amp-anim');
 
-        ampAnimEl = setAllowedAttributes(
-          allowedAMPAttributes['amp-anim'],
-          imgEl,
-          ampAnimEl
-        );
+        ampAnimEl = setAllowedAttributes('amp-anim', imgEl, ampAnimEl);
         ampAnimEl.setAttribute('layout', layoutType);
 
         // Set element type for dynamically loading scripts in template
@@ -135,7 +129,7 @@ const generateAMPObj = async obj => {
         let ampYouTubeEl = document.createElement('amp-youtube');
 
         ampYouTubeEl = setAllowedAttributes(
-          allowedAMPAttributes['amp-youtube'],
+          'amp-youtube',
           iframeEl,
           ampYouTubeEl
         );
@@ -150,11 +144,7 @@ const generateAMPObj = async obj => {
         // Create <amp-iframe> elements
         let ampIframeEl = document.createElement('amp-iframe');
 
-        ampIframeEl = setAllowedAttributes(
-          allowedAMPAttributes['amp-iframe'],
-          iframeEl,
-          ampIframeEl
-        );
+        ampIframeEl = setAllowedAttributes('amp-iframe', iframeEl, ampIframeEl);
         ampIframeEl.setAttribute('layout', 'responsive');
 
         // Special handling for the sandbox attribute
@@ -177,11 +167,7 @@ const generateAMPObj = async obj => {
       const sourceEls = [...audioEl.getElementsByTagName('source')];
       let ampAudioEl = document.createElement('amp-audio');
 
-      ampAudioEl = setAllowedAttributes(
-        allowedAMPAttributes['amp-audio'],
-        audioEl,
-        ampAudioEl
-      );
+      ampAudioEl = setAllowedAttributes('amp-audio', audioEl, ampAudioEl);
 
       // Add source elements as children
       sourceEls.forEach(source => ampAudioEl.appendChild(source));
@@ -201,11 +187,7 @@ const generateAMPObj = async obj => {
       const sourceEls = [...videoEl.getElementsByTagName('source')];
       let ampVideoEl = document.createElement('amp-video');
 
-      ampVideoEl = setAllowedAttributes(
-        allowedAMPAttributes['amp-video'],
-        videoEl,
-        ampVideoEl
-      );
+      ampVideoEl = setAllowedAttributes('amp-video', videoEl, ampVideoEl);
       ampVideoEl.setAttribute('layout', 'responsive');
       // Ensure controls are set
       ampVideoEl.setAttribute('controls', '');

--- a/utils/ghost/generate-amp-obj.js
+++ b/utils/ghost/generate-amp-obj.js
@@ -32,7 +32,7 @@ const generateAMPObj = async obj => {
     allowedAttributesArr.forEach(attribute => {
       const booleanAttributes = ['loop', 'autoplay', 'muted'];
 
-      if (originalEl[attribute]) {
+      if (originalEl.hasAttribute(attribute)) {
         // Add boolean attribute to the ampEl so it is present,
         // but prevent it from being set to "true"
         if (booleanAttributes.includes(attribute)) {
@@ -174,7 +174,7 @@ const generateAMPObj = async obj => {
       let ampAudio = document.createElement('amp-audio');
 
       ampAudio = setAllowedAttributes(
-        [...allowedAMPAttributes['amp-audio'], 'controlsList'],
+        allowedAMPAttributes['amp-audio'],
         audio,
         ampAudio
       );
@@ -198,7 +198,7 @@ const generateAMPObj = async obj => {
       let ampVideo = document.createElement('amp-video');
 
       ampVideo = setAllowedAttributes(
-        [...allowedAMPAttributes['amp-video'], 'controlsList'],
+        allowedAMPAttributes['amp-video'],
         video,
         ampVideo
       );

--- a/utils/ghost/generate-amp-obj.js
+++ b/utils/ghost/generate-amp-obj.js
@@ -29,9 +29,19 @@ const generateAMPObj = async obj => {
   const videoEls = [...document.getElementsByTagName('video')];
 
   const setAllowedAttributes = (allowedAttributesArr, originalEl, ampEl) => {
-    allowedAttributesArr.forEach(attr =>
-      originalEl[attr] ? ampEl.setAttribute(attr, originalEl[attr]) : ''
-    );
+    allowedAttributesArr.forEach(attribute => {
+      const booleanAttributes = ['loop', 'autoplay', 'muted'];
+
+      if (originalEl[attribute]) {
+        // Add boolean attribute to the ampEl so it is present,
+        // but prevent it from being set to "true"
+        if (booleanAttributes.includes(attribute)) {
+          return ampEl.setAttribute(attribute, '');
+        }
+
+        return ampEl.setAttribute(attribute, originalEl[attribute]);
+      }
+    });
 
     return ampEl;
   };

--- a/utils/transforms/html-sanitizer.js
+++ b/utils/transforms/html-sanitizer.js
@@ -289,8 +289,8 @@ const allowedAMPAttributes = {
     'attribution',
     'autoplay',
     'controls',
+    'controlsList',
     'loop',
-    'muted',
     'poster',
     'preload'
   ],
@@ -334,7 +334,8 @@ const allowedAMPAttributes = {
     'autoplay',
     'loop',
     'muted',
-    'controls'
+    'controls',
+    'controlsList'
   ],
   'amp-iframe': [
     'src',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes a few remaining errors that were reported by Google Search Console regarding AMP pages, and includes some refactoring.

The main fix is to the `setAllowedAttributes` function in `generate-amp-obj.js`, which now has special handling for boolean attributes like `muted` and `autoplay` which can be included in `audio` and `video` elements. AMP elements are quite particular about these, and they should now appear in the plain `attributeName` form, for example, `<amp-video src="..." autoplay muted loop>`.

There are also some new tests to check that `muted`, `autoplay`, and `loop` are set and do not contain unexpected values.

The other changes are due to some refactoring.

The changes in `generate-amp-obj.js` are mainly updates to variable names to help with readability.

And the changes in `amp.spec.js` are to test all the AMP elements of each type only contain the allowed AMP elements from `html-sanitizer.js`. For example, that all `amp-audio` elements only contain `src`, `width`, `height`, `autoplay`, `loop`, `muted`, `controls`, and `controlsList` attributes, along with some expected AMP attributes that get appended when the page renders.