### PR TITLE
fix: add an ia-to-ai redirect for a recent article

### DIFF
--- a/docker-config/languages/english/serve.json
+++ b/docker-config/languages/english/serve.json
@@ -28,6 +28,11 @@
       "destination": "/news/about"
     },
     {
+      "source": "/train-an-ia-to-play-a-snake-game-using-python",
+      "destination": "/news/train-an-ai-to-play-a-snake-game-using-python",
+      "type": 302
+    },
+    {
       "source": "/fullstack-development-project-create-a-blog-with-html-css",
       "destination": "/news/frontend-development-project-create-a-blog-with-html-css",
       "type": 302


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This adds a redirect for a recently published article with a minor typo in the slug (/train-an-ia-to-play-a-snake-game-using-python to train-an-ai-to-play-a-snake-game-using-python).

The slug has been updated on Ghost, and the article should be available with the fixed slug after the next scheduled build.

- Original URL: https://www.freecodecamp.org/news/train-an-ia-to-play-a-snake-game-using-python/
- Fixed URL: https://www.freecodecamp.org/news/train-an-ai-to-play-a-snake-game-using-python/