### PR TITLE
fix: Japanese donor string

### DIFF
--- a/i18n/locales/japanese/translations.json
+++ b/i18n/locales/japanese/translations.json
@@ -14,7 +14,7 @@
   "banner": {
     "default": "コーディングを学ぶ — {{ <0> }}約 3,000 時間のカリキュラムが無料{{ </0> }}",
     "authenticated": "当非営利団体とその使命をご支援ください。{{ <0> }}freeCodeCamp.org へのご寄付をお願いします{{ </0> }}。",
-    "authenticated-donor": "への{{ <0> }}ご寄付{{ </0> }}によるご支援、誠にありがとうございます。"
+    "authenticated-donor": "freeCodeCamp への{{ <0> }}ご寄付{{ </0> }}によるご支援、誠にありがとうございます。"
   },
   "author": {
     "no-posts": "投稿なし",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Adds the missing "freeCodeCamp" to the Japanese donor string for the banner.