### PR TITLE
fix: JSON-LD destructuring error

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,7 +12,7 @@ const {
 } = require('./utils/shortcodes/images');
 const cacheBusterShortcode = require('./utils/shortcodes/cache-buster');
 const sitemapFetcherShortcode = require('./utils/shortcodes/sitemap-fetcher');
-const createJsonLdShortcode = require('./utils/shortcodes/create-json-ld');
+const createJSONLDShortcode = require('./utils/shortcodes/create-json-ld');
 const {
   publishedDateShortcode,
   timeAgoShortcode,
@@ -66,7 +66,7 @@ module.exports = function (config) {
 
   config.addNunjucksShortcode('fullEscaper', fullEscaper);
 
-  config.addNunjucksAsyncShortcode('createJsonLd', createJsonLdShortcode);
+  config.addNunjucksAsyncShortcode('createJSONLD', createJSONLDShortcode);
 
   config.addNunjucksAsyncShortcode('sitemapFetcher', sitemapFetcherShortcode);
 

--- a/src/_includes/layouts/amp.njk
+++ b/src/_includes/layouts/amp.njk
@@ -52,7 +52,7 @@
     <meta property="og:image:width" content="{{ post.image_dimensions.feature_image.width }}">
     <meta property="og:image:height" content="{{ post.image_dimensions.feature_image.height }}">
 
-    <script type="application/ld+json">{% createJsonLd 'article', site, post %}</script>
+    <script type="application/ld+json">{% createJSONLD 'article', site, post %}</script>
 
     <meta name="generator" content="Eleventy">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ site.url + "/rss/" }}">

--- a/src/_includes/layouts/author.njk
+++ b/src/_includes/layouts/author.njk
@@ -55,5 +55,5 @@
 {% endblock %}
 
 {% block jsonLd %}
-    <script type="application/ld+json">{% createJsonLd 'author', site, author %}</script>
+    <script type="application/ld+json">{% createJSONLD 'author', site, author %}</script>
 {% endblock %}

--- a/src/_includes/layouts/doc.njk
+++ b/src/_includes/layouts/doc.njk
@@ -105,5 +105,5 @@
 {% endblock %}
 
 {% block jsonLd %}
-    <script type="application/ld+json">{% createJsonLd 'article', site, doc %}</script>
+    <script type="application/ld+json">{% createJSONLD 'article', site, doc %}</script>
 {% endblock %}

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -175,5 +175,5 @@ time #}
 {% endblock %}
 
 {% block jsonLd %}
-    <script type="application/ld+json">{% createJsonLd 'article', site, post %}</script>
+    <script type="application/ld+json">{% createJSONLD 'article', site, post %}</script>
 {% endblock %}

--- a/src/_includes/layouts/tag.njk
+++ b/src/_includes/layouts/tag.njk
@@ -64,5 +64,5 @@
 {% endblock %}
 
 {% block jsonLd %}
-    <script type="application/ld+json">{% createJsonLd 'tag', site, tag %}</script>
+    <script type="application/ld+json">{% createJSONLD 'tag', site, tag %}</script>
 {% endblock %}

--- a/src/index.njk
+++ b/src/index.njk
@@ -31,5 +31,5 @@ pagination:
 {% endblock %}
 
 {% block jsonLd %}
-    <script type="application/ld+json">{% createJsonLd 'index', site %}</script>
+    <script type="application/ld+json">{% createJSONLD 'index', site %}</script>
 {% endblock %}

--- a/utils/get-image-dimensions.js
+++ b/utils/get-image-dimensions.js
@@ -2,12 +2,15 @@ const probe = require('probe-image-size');
 const errorLogger = require('./error-logger');
 // Cache image dimensions we know will be repeated, like author profile and cover images
 const imageDimensionMap = {};
+const defaultDimensions = { width: 600, height: 400 };
 
 const getImageDimensions = async (url, title, cache) => {
   try {
     if (cache && imageDimensionMap[url]) return imageDimensionMap[url];
 
-    const { width, height } = await probe(url);
+    const res = await probe(url);
+    const width = res.width ? res.width : defaultDimensions.width;
+    const height = res.height ? res.height : defaultDimensions.height;
 
     if (cache) {
       imageDimensionMap[url] = { width, height };
@@ -21,8 +24,8 @@ const getImageDimensions = async (url, title, cache) => {
     if (err.statusCode) errorLogger({ type: 'image', name: title }); // Only write HTTP status code errors to log
 
     return {
-      width: 600,
-      height: 400
+      width: defaultDimensions.width,
+      height: defaultDimensions.height
     };
   }
 };

--- a/utils/shortcodes/create-json-ld.js
+++ b/utils/shortcodes/create-json-ld.js
@@ -2,10 +2,53 @@ const fullEscaper = require('../full-escaper');
 const translate = require('../translate');
 const { siteURL } = require('../../config');
 
+const createImageObj = (url, obj) => {
+  const width = obj.width ? obj.width : 600;
+  const height = obj.height ? obj.height : 400;
+
+  return {
+    '@type': 'ImageObject',
+    url,
+    width,
+    height
+  };
+};
+
+const createAuthorObj = primaryAuthor => {
+  const {
+    name,
+    profile_image,
+    image_dimensions,
+    website,
+    twitter,
+    facebook,
+    path
+  } = primaryAuthor;
+  const authorObj = {
+    '@type': 'Person',
+    name,
+    url: siteURL + path,
+    sameAs: [
+      website ? fullEscaper(website) : null,
+      facebook ? `https://www.facebook.com/${facebook}` : null,
+      twitter ? twitter.replace('@', 'https://twitter.com/') : null
+    ].filter(url => url)
+  };
+
+  if (profile_image) {
+    authorObj.image = createImageObj(
+      profile_image,
+      image_dimensions.profile_image
+    );
+  }
+
+  return authorObj;
+};
+
 async function createJsonLdShortcode(type, site, data) {
   // Main site settings from site object
   const { logo, cover_image, image_dimensions } = site;
-  const url = `${site.url}/`;
+  const url = `${siteURL}/`;
   const typeMap = {
     index: 'WebSite',
     article: 'Article',
@@ -30,51 +73,8 @@ async function createJsonLdShortcode(type, site, data) {
   };
   const returnData = { ...baseData };
 
-  const createImageObj = (url, obj) => {
-    const width = obj.width ? obj.width : 600;
-    const height = obj.height ? obj.height : 400;
-
-    return {
-      '@type': 'ImageObject',
-      url,
-      width,
-      height
-    };
-  };
-
   // Conditionally set other properties based on
   // objects passed to shortcodes
-  const createAuthorObj = primaryAuthor => {
-    const {
-      name,
-      profile_image,
-      image_dimensions,
-      website,
-      twitter,
-      facebook,
-      path
-    } = primaryAuthor;
-    const authorObj = {
-      '@type': 'Person',
-      name,
-      url: siteURL + path,
-      sameAs: [
-        website ? fullEscaper(website) : null,
-        facebook ? `https://www.facebook.com/${facebook}` : null,
-        twitter ? twitter.replace('@', 'https://twitter.com/') : null
-      ].filter(url => url)
-    };
-
-    if (profile_image) {
-      authorObj.image = createImageObj(
-        profile_image,
-        image_dimensions.profile_image
-      );
-    }
-
-    return authorObj;
-  };
-
   if (type === 'index')
     returnData.description = translate('meta-tags:description');
 

--- a/utils/shortcodes/create-json-ld.js
+++ b/utils/shortcodes/create-json-ld.js
@@ -2,9 +2,8 @@ const fullEscaper = require('../full-escaper');
 const translate = require('../translate');
 const { siteURL } = require('../../config');
 
-const createImageObj = (url, obj) => {
-  const width = obj.width ? obj.width : 600;
-  const height = obj.height ? obj.height : 400;
+const createImageObj = (url, imageDimensions) => {
+  const { width, height } = imageDimensions;
 
   return {
     '@type': 'ImageObject',

--- a/utils/shortcodes/create-json-ld.js
+++ b/utils/shortcodes/create-json-ld.js
@@ -19,19 +19,9 @@ async function createJsonLdShortcode(type, site, data) {
       '@type': 'Organization',
       name: 'freeCodeCamp.org',
       url: url,
-      logo: {
-        '@type': 'ImageObject',
-        url: logo,
-        width: image_dimensions.logo.width,
-        height: image_dimensions.logo.height
-      }
+      logo: createImageObj(logo, image_dimensions.logo)
     },
-    image: {
-      '@type': 'ImageObject',
-      url: cover_image,
-      width: image_dimensions.cover_image.width,
-      height: image_dimensions.cover_image.height
-    },
+    image: createImageObj(cover_image, image_dimensions.cover_image),
     url: url,
     mainEntityOfPage: {
       '@type': 'WebPage',
@@ -41,7 +31,8 @@ async function createJsonLdShortcode(type, site, data) {
   const returnData = { ...baseData };
 
   const createImageObj = (url, obj) => {
-    let { width, height } = obj;
+    const width = obj.width ? obj.width : 600;
+    const height = obj.height ? obj.height : 400;
 
     return {
       '@type': 'ImageObject',

--- a/utils/shortcodes/create-json-ld.js
+++ b/utils/shortcodes/create-json-ld.js
@@ -45,7 +45,7 @@ const createAuthorObj = primaryAuthor => {
   return authorObj;
 };
 
-async function createJsonLdShortcode(type, site, data) {
+async function createJSONLDShortcode(type, site, data) {
   // Main site settings from site object
   const { logo, cover_image, image_dimensions } = site;
   const url = `${siteURL}/`;
@@ -154,4 +154,4 @@ async function createJsonLdShortcode(type, site, data) {
   // return JSON.stringify(returnData);
 }
 
-module.exports = createJsonLdShortcode;
+module.exports = createJSONLDShortcode;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

These updates (besides the cosmetic change of `createJsonLD` --> `createJSONLD`) should prevent failed builds like the one here: https://dev.azure.com/freeCodeCamp-org/news/_build/results?buildId=2974&view=logs&j=cfa20e98-6997-523c-4233-f0a7302c929f&t=5c905a96-3bb6-59d7-582d-bfe05b84cd76&l=826

It's not a true fix in the sense that there may still be times when an image's width or height is undefined. This may be due to an error with the API, or with the way we're processing batches now.

But this should provide a default width or height if either are missing, and allow the build to proceed.