### PR TITLE
fix: add additional image dimension error handling

### DIFF
--- a/utils/shortcodes/create-json-ld.js
+++ b/utils/shortcodes/create-json-ld.js
@@ -3,7 +3,10 @@ const translate = require('../translate');
 const { siteURL } = require('../../config');
 
 const createImageObj = (url, imageDimensions) => {
-  const { width, height } = imageDimensions;
+  // To do: Look into why tags with a feature_image sometimes have
+  // an undefined width and/or height
+  const width = imageDimensions.width ? imageDimensions.width : 1920;
+  const height = imageDimensions.height ? imageDimensions.height : 1080;
 
   return {
     '@type': 'ImageObject',


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Hopefully this tweak will help prevent future failed builds due to [images with missing widths or heights](https://dev.azure.com/freeCodeCamp-org/news/_build/results?buildId=3060&view=logs&j=275f1d19-1bd8-5591-b06b-07d489ea915a&t=29b11093-f299-52c9-fc3e-b4e81abf4ac1&l=15449).

Will need to investigate why this only seems to happen for tag pages with a feature image. We may also need to look into other image size libraries.