### PR TITLE
feat: add files for French and Korean publications

### DIFF
--- a/config/i18n/locales/dothraki/translations.json
+++ b/config/i18n/locales/dothraki/translations.json
@@ -57,8 +57,10 @@
       "chinese": "Chinese",
       "english": "English",
       "espanol": "Spanish",
+      "french": "French",
       "italian": "Italian",
       "japanese": "Japanese",
+      "korean": "Korean",
       "portuguese": "Portuguese",
       "swahili": "Swahili",
       "urdu": "Urdu"

--- a/config/i18n/locales/english/translations.json
+++ b/config/i18n/locales/english/translations.json
@@ -57,8 +57,10 @@
       "chinese": "Chinese",
       "english": "English",
       "espanol": "Spanish",
+      "french": "French",
       "italian": "Italian",
       "japanese": "Japanese",
+      "korean": "Korean",
       "portuguese": "Portuguese",
       "swahili": "Swahili",
       "urdu": "Urdu"

--- a/config/i18n/locales/french/links.json
+++ b/config/i18n/locales/french/links.json
@@ -1,0 +1,17 @@
+{
+  "forum": "https://forum.freecodecamp.org/",
+  "donate": "https://www.freecodecamp.org/donate/",
+  "banner": {
+    "default": "https://www.freecodecamp.org/",
+    "authenticated": "https://www.freecodecamp.org/donate",
+    "authenticated-donor": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp/"
+  },
+  "learn-to-code-cta": "https://www.freecodecamp.org/learn/",
+  "twitter": "https://twitter.com/freecodecamp",
+  "footer": {
+    "about": "https://www.freecodecamp.org/news/about/",
+    "support": "https://www.freecodecamp.org/news/support/",
+    "honesty": "https://www.freecodecamp.org/news/academic-honesty-policy/",
+    "coc": "https://www.freecodecamp.org/news/code-of-conduct/"
+  }
+}

--- a/config/i18n/locales/french/meta-tags.json
+++ b/config/i18n/locales/french/meta-tags.json
@@ -1,0 +1,5 @@
+{
+  "title": "freeCodeCamp Programming Tutorials: Python, JavaScript, Git & More",
+  "keywords": "freeCodeCamp, programming, front-end, programmer, article, regular expressions, Python, JavaScript, AWS, JSON, HTML, CSS, Bootstrap, React, Vue, Webpack",
+  "description": "Browse thousands of programming tutorials written by experts. Learn Web Development, Data Science, DevOps, Security, and get developer career advice."
+}

--- a/config/i18n/locales/french/serve.json
+++ b/config/i18n/locales/french/serve.json
@@ -1,0 +1,24 @@
+{
+  "redirects": [
+    {
+      "source": "/@:authorName",
+      "destination": "/french/news/author/:authorName"
+    },
+    {
+      "source": "/tagged/:tagName",
+      "destination": "/french/news/tag/:tagName"
+    },
+    {
+      "source": "/archive/:archiveSlug?",
+      "destination": "/french/news"
+    },
+    {
+      "source": "/our-sponsors",
+      "destination": "/french/news/sponsors"
+    },
+    {
+      "source": "/about-freecodecamp",
+      "destination": "/french/news/about"
+    }
+  ]
+}

--- a/config/i18n/locales/french/translations.json
+++ b/config/i18n/locales/french/translations.json
@@ -1,0 +1,94 @@
+{
+  "buttons": {
+    "forum": "Forum",
+    "donate": "Donate",
+    "load-more-articles": "Load More Articles"
+  },
+  "search": {
+    "label": "Search",
+    "accessible-name": "Submit your search query",
+    "placeholder": "Search 8,000+ tutorials",
+    "see-results": "See all results for {{ searchQuery }}",
+    "no-tutorials": "No tutorials found"
+  },
+  "banner": {
+    "default": "Learn to code — {{ <0> }}free 3,000-hour curriculum{{ </0> }}",
+    "authenticated": "Support our nonprofit and our mission. {{ <0> }}Donate to freeCodeCamp.org{{ </0> }}.",
+    "authenticated-donor": "Thank you for supporting freeCodeCamp through {{ <0> }}your donations{{ </0> }}."
+  },
+  "default-bio": "Read {{ <0> }}more posts{{ </0> }}.",
+  "author": {
+    "no-posts": "No posts",
+    "one-post": "1 post",
+    "multiple-posts": "{{ postCount }} posts"
+  },
+  "tag": {
+    "no-posts": "A collection of posts",
+    "one-post": "A collection of 1 post",
+    "multiple-posts": "A collection of {{ postCount }} posts"
+  },
+  "404": {
+    "page-not-found": "Page not found",
+    "go-to-front-page": "Go to the front page"
+  },
+  "social-row": {
+    "cta": {
+      "tweet-a-thanks": "If you read this far, tweet to the author to show them you care. {{ <0> }}Tweet a thanks{{ </0> }}",
+      "tweet-it": "If this article was helpful, {{ <0> }}tweet it{{ </0> }}."
+    },
+    "tweets": {
+      "default": "Thank you {{ author }} for writing this helpful article.",
+      "translation": "Thank you {{ author }} for writing this helpful article, and {{ translator }} for translating it."
+    }
+  },
+  "learn-to-code-cta": "Learn to code for free. freeCodeCamp's open source curriculum has helped more than 40,000 people get jobs as developers. {{ <0> }}Get started{{ </0> }}",
+  "original-author-translator": {
+    "roles": {
+      "author": "Author: {{ name }} ({{ locale }})",
+      "translator": "Translator: {{ name }}"
+    },
+    "details": {
+      "original-article": "{{ <0> }}Original article:{{ </0> }} {{ title }} by {{ author }}",
+      "translated-by": "{{ <0> }}Translated by:{{ </0> }} {{ translator }}"
+    },
+    "locales": {
+      "arabic": "Arabic",
+      "bengali": "Bengali",
+      "chinese": "Chinese",
+      "english": "English",
+      "espanol": "Spanish",
+      "italian": "Italian",
+      "japanese": "Japanese",
+      "portuguese": "Portuguese",
+      "swahili": "Swahili",
+      "urdu": "Urdu"
+    }
+  },
+  "embed-title": "Embedded content",
+  "footer": {
+    "tax-exempt-status": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) nonprofit organization (United States Federal Tax Identification Number: 82-0779546)",
+    "mission-statement": "Our mission: to help people learn to code for free. We accomplish this by creating thousands of videos, articles, and interactive coding lessons - all freely available to the public. We also have thousands of freeCodeCamp study groups around the world.",
+    "donation-initiatives": "Donations to freeCodeCamp go toward our education initiatives, and help pay for servers, services, and staff.",
+    "donate-text": "You can {{ <0> }}make a tax-deductible donation here{{ </0> }}.",
+    "trending-guides": "Trending Guides",
+    "our-nonprofit": "Our Nonprofit",
+    "links": {
+      "about": "About",
+      "alumni": "Alumni Network",
+      "open-source": "Open Source",
+      "shop": "Shop",
+      "support": "Support",
+      "sponsors": "Sponsors",
+      "honesty": "Academic Honesty",
+      "coc": "Code of Conduct",
+      "privacy": "Privacy Policy",
+      "tos": "Terms of Service",
+      "copyright": "Copyright Policy"
+    }
+  },
+  "fallback": {
+    "message": "Your browser doesn't support HTML5 {{ element }}.",
+    "audio": "audio",
+    "video": "video"
+  }
+}

--- a/config/i18n/locales/french/translations.json
+++ b/config/i18n/locales/french/translations.json
@@ -57,8 +57,10 @@
       "chinese": "Chinese",
       "english": "English",
       "espanol": "Spanish",
+      "french": "French",
       "italian": "Italian",
       "japanese": "Japanese",
+      "korean": "Korean",
       "portuguese": "Portuguese",
       "swahili": "Swahili",
       "urdu": "Urdu"

--- a/config/i18n/locales/korean/links.json
+++ b/config/i18n/locales/korean/links.json
@@ -1,0 +1,17 @@
+{
+  "forum": "https://forum.freecodecamp.org/",
+  "donate": "https://www.freecodecamp.org/donate/",
+  "banner": {
+    "default": "https://www.freecodecamp.org/",
+    "authenticated": "https://www.freecodecamp.org/donate",
+    "authenticated-donor": "https://www.freecodecamp.org/news/how-to-donate-to-free-code-camp/"
+  },
+  "learn-to-code-cta": "https://www.freecodecamp.org/learn/",
+  "twitter": "https://twitter.com/freecodecamp",
+  "footer": {
+    "about": "https://www.freecodecamp.org/news/about/",
+    "support": "https://www.freecodecamp.org/news/support/",
+    "honesty": "https://www.freecodecamp.org/news/academic-honesty-policy/",
+    "coc": "https://www.freecodecamp.org/news/code-of-conduct/"
+  }
+}

--- a/config/i18n/locales/korean/meta-tags.json
+++ b/config/i18n/locales/korean/meta-tags.json
@@ -1,0 +1,5 @@
+{
+  "title": "freeCodeCamp Programming Tutorials: Python, JavaScript, Git & More",
+  "keywords": "freeCodeCamp, programming, front-end, programmer, article, regular expressions, Python, JavaScript, AWS, JSON, HTML, CSS, Bootstrap, React, Vue, Webpack",
+  "description": "Browse thousands of programming tutorials written by experts. Learn Web Development, Data Science, DevOps, Security, and get developer career advice."
+}

--- a/config/i18n/locales/korean/serve.json
+++ b/config/i18n/locales/korean/serve.json
@@ -1,0 +1,24 @@
+{
+  "redirects": [
+    {
+      "source": "/@:authorName",
+      "destination": "/korean/news/author/:authorName"
+    },
+    {
+      "source": "/tagged/:tagName",
+      "destination": "/korean/news/tag/:tagName"
+    },
+    {
+      "source": "/archive/:archiveSlug?",
+      "destination": "/korean/news"
+    },
+    {
+      "source": "/our-sponsors",
+      "destination": "/korean/news/sponsors"
+    },
+    {
+      "source": "/about-freecodecamp",
+      "destination": "/korean/news/about"
+    }
+  ]
+}

--- a/config/i18n/locales/korean/translations.json
+++ b/config/i18n/locales/korean/translations.json
@@ -1,0 +1,94 @@
+{
+  "buttons": {
+    "forum": "Forum",
+    "donate": "Donate",
+    "load-more-articles": "Load More Articles"
+  },
+  "search": {
+    "label": "Search",
+    "accessible-name": "Submit your search query",
+    "placeholder": "Search 8,000+ tutorials",
+    "see-results": "See all results for {{ searchQuery }}",
+    "no-tutorials": "No tutorials found"
+  },
+  "banner": {
+    "default": "Learn to code — {{ <0> }}free 3,000-hour curriculum{{ </0> }}",
+    "authenticated": "Support our nonprofit and our mission. {{ <0> }}Donate to freeCodeCamp.org{{ </0> }}.",
+    "authenticated-donor": "Thank you for supporting freeCodeCamp through {{ <0> }}your donations{{ </0> }}."
+  },
+  "default-bio": "Read {{ <0> }}more posts{{ </0> }}.",
+  "author": {
+    "no-posts": "No posts",
+    "one-post": "1 post",
+    "multiple-posts": "{{ postCount }} posts"
+  },
+  "tag": {
+    "no-posts": "A collection of posts",
+    "one-post": "A collection of 1 post",
+    "multiple-posts": "A collection of {{ postCount }} posts"
+  },
+  "404": {
+    "page-not-found": "Page not found",
+    "go-to-front-page": "Go to the front page"
+  },
+  "social-row": {
+    "cta": {
+      "tweet-a-thanks": "If you read this far, tweet to the author to show them you care. {{ <0> }}Tweet a thanks{{ </0> }}",
+      "tweet-it": "If this article was helpful, {{ <0> }}tweet it{{ </0> }}."
+    },
+    "tweets": {
+      "default": "Thank you {{ author }} for writing this helpful article.",
+      "translation": "Thank you {{ author }} for writing this helpful article, and {{ translator }} for translating it."
+    }
+  },
+  "learn-to-code-cta": "Learn to code for free. freeCodeCamp's open source curriculum has helped more than 40,000 people get jobs as developers. {{ <0> }}Get started{{ </0> }}",
+  "original-author-translator": {
+    "roles": {
+      "author": "Author: {{ name }} ({{ locale }})",
+      "translator": "Translator: {{ name }}"
+    },
+    "details": {
+      "original-article": "{{ <0> }}Original article:{{ </0> }} {{ title }} by {{ author }}",
+      "translated-by": "{{ <0> }}Translated by:{{ </0> }} {{ translator }}"
+    },
+    "locales": {
+      "arabic": "Arabic",
+      "bengali": "Bengali",
+      "chinese": "Chinese",
+      "english": "English",
+      "espanol": "Spanish",
+      "italian": "Italian",
+      "japanese": "Japanese",
+      "portuguese": "Portuguese",
+      "swahili": "Swahili",
+      "urdu": "Urdu"
+    }
+  },
+  "embed-title": "Embedded content",
+  "footer": {
+    "tax-exempt-status": "freeCodeCamp is a donor-supported tax-exempt 501(c)(3) nonprofit organization (United States Federal Tax Identification Number: 82-0779546)",
+    "mission-statement": "Our mission: to help people learn to code for free. We accomplish this by creating thousands of videos, articles, and interactive coding lessons - all freely available to the public. We also have thousands of freeCodeCamp study groups around the world.",
+    "donation-initiatives": "Donations to freeCodeCamp go toward our education initiatives, and help pay for servers, services, and staff.",
+    "donate-text": "You can {{ <0> }}make a tax-deductible donation here{{ </0> }}.",
+    "trending-guides": "Trending Guides",
+    "our-nonprofit": "Our Nonprofit",
+    "links": {
+      "about": "About",
+      "alumni": "Alumni Network",
+      "open-source": "Open Source",
+      "shop": "Shop",
+      "support": "Support",
+      "sponsors": "Sponsors",
+      "honesty": "Academic Honesty",
+      "coc": "Code of Conduct",
+      "privacy": "Privacy Policy",
+      "tos": "Terms of Service",
+      "copyright": "Copyright Policy"
+    }
+  },
+  "fallback": {
+    "message": "Your browser doesn't support HTML5 {{ element }}.",
+    "audio": "audio",
+    "video": "video"
+  }
+}

--- a/config/i18n/locales/korean/translations.json
+++ b/config/i18n/locales/korean/translations.json
@@ -57,8 +57,10 @@
       "chinese": "Chinese",
       "english": "English",
       "espanol": "Spanish",
+      "french": "French",
       "italian": "Italian",
       "japanese": "Japanese",
+      "korean": "Korean",
       "portuguese": "Portuguese",
       "swahili": "Swahili",
       "urdu": "Urdu"

--- a/config/i18n/redirects.test.js
+++ b/config/i18n/redirects.test.js
@@ -45,25 +45,16 @@ describe('Redirect and rewrite tests:', () => {
       });
 
       test('internal redirects point to the correct base path', () => {
-        const expectedBasePath = {
-          arabic: /^\/arabic\/news/,
-          bengali: /^\/bengali\/news/,
-          chinese: /^\/news/,
-          dothraki: /^\/dothraki\/news/,
-          english: /^\/news/,
-          espanol: /^\/espanol\/news/,
-          italian: /^\/italian\/news/,
-          japanese: /^\/japanese\/news/,
-          portuguese: /^\/portuguese\/news/,
-          swahili: /^\/swahili\/news/,
-          urdu: /^\/urdu\/news/
-        };
-
         redirects
           .filter(redirect => redirect.destination.startsWith('/'))
-          .map(redirect =>
-            expect(redirect.destination).toMatch(expectedBasePath[lang])
-          );
+          .map(redirect => {
+            const expectedBasePath =
+              lang === 'english' || lang === 'chinese'
+                ? new RegExp(`^/news(/|$)`)
+                : new RegExp(`^/${lang}/news(/|$)`);
+
+            expect(redirect.destination).toMatch(expectedBasePath);
+          });
       });
 
       test('there are no duplicate redirects', () => {

--- a/config/index.js
+++ b/config/index.js
@@ -26,8 +26,10 @@ const locales = [
   'chinese',
   'english',
   'espanol',
+  'french',
   'italian',
   'japanese',
+  'korean',
   'portuguese',
   'swahili',
   'urdu'
@@ -43,8 +45,10 @@ const localeCodes = {
   chinese: 'zh',
   english: 'en',
   espanol: 'es',
+  french: 'fr',
   italian: 'it',
   japanese: 'ja',
+  korean: 'ko',
   portuguese: 'pt-BR',
   swahili: 'sw',
   urdu: 'ur'
@@ -56,8 +60,10 @@ const algoliaIndices = {
   chinese: 'news-zh',
   english: 'news',
   espanol: 'news-es',
+  french: 'news-fr',
   italian: 'news-it',
   japanese: 'news-ja',
+  korean: 'news-ko',
   portuguese: 'news-pt-br',
   swahili: 'news-sw',
   urdu: 'news-ur'


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/cdn/pull/151

<!-- Feel free to add any additional description of changes below this line -->
Once https://github.com/freeCodeCamp/cdn/pull/151 is in, this will allow us to build the new French and Korean publications locally.

I did a couple of test builds by merging a PR to my fork of the CDN repo to add Korean and French `trending.yaml` files, and everything seems to work as expected.

This PR also simplifies one of the tests in `redirects.test.js`, and should make it easier to deploy publications in the future.

Note: I believe the reason why the Firefox tests are failing is that there's an issue connecting to FF 103 from Cypress 9. We may need to migrate to Cypress 10 to fix this.