### PR TITLE
fix: normal word-break for inline code

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -965,7 +965,7 @@ Usage (In Ghost editor):
 }
 
 .post-full-content p code {
-  word-break: break-all;
+  word-break: normal;
 }
 
 .post-full-content pre {
@@ -2504,7 +2504,6 @@ a.banner:hover span {
 }
 
 .rtl-layout .post-full-content p code {
-  word-break: normal;
   direction: ltr;
   unicode-bidi: isolate;
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This should fix issues where inline code breaks anywhere if the content would otherwise go to the next line or overflow from the container.

Setting `word-break` to `normal` should prevent issues like this:

![image](https://user-images.githubusercontent.com/2051070/184078678-214b0c7b-0cfa-457d-855a-684dc2c4b35f.png)

@ahmadabdolsaheb and I discussed using `word-break: break-word` here, but it turns out that's been deprecated. Browsers still accept it, but treat it the same as either `word-break: normal` or `overflow-wrap: anywhere`.

Here is the same text after the change:

![image](https://user-images.githubusercontent.com/2051070/184078813-894d28d9-6ed9-4389-9d90-7514c555d7a7.png)

It's possible that long, unbroken lines of inline code will overflow from the container, but that is something that can be fixed after the fact in the Ghost editor through rewrites and moving that code into code blocks.