### PR TITLE
fix: heading styles and sizes

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -152,7 +152,7 @@ body {
 
 @media (max-width: 500px) {
   .site-title {
-    font-size: 3rem;
+    font-size: 3.2rem;
   }
 
   .site-description {
@@ -1033,7 +1033,7 @@ Usage (In Ghost editor):
 
 @media (max-width: 500px) {
   .post-full-content h1 {
-    font-size: 3rem;
+    font-size: 3.2rem;
   }
 }
 
@@ -1043,7 +1043,7 @@ Usage (In Ghost editor):
 
 @media (max-width: 500px) {
   .post-full-content h2 {
-    font-size: 2.8rem;
+    font-size: 3rem;
   }
 }
 
@@ -1115,7 +1115,7 @@ Usage (In Ghost editor):
   }
 
   .post-full-title {
-    font-size: 2.9rem;
+    font-size: 3.2rem;
   }
 
   .post-full-image {

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -1023,87 +1023,62 @@ Usage (In Ghost editor):
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
     Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
   font-display: swap;
+  font-weight: 700;
+  margin: 0.5em 0 0.2em;
 }
 
 .post-full-content h1 {
-  margin: 0.5em 0 0.2em;
   font-size: 4.6rem;
-  font-weight: 700;
 }
 
 @media (max-width: 500px) {
   .post-full-content h1 {
-    font-size: 2.8rem;
+    font-size: 3rem;
   }
 }
 
 .post-full-content h2 {
-  margin: 0.5em 0 0.2em;
   font-size: 3.6rem;
-  font-weight: 700;
 }
 
 @media (max-width: 500px) {
   .post-full-content h2 {
-    font-size: 2.6rem;
+    font-size: 2.8rem;
   }
 }
 
 .post-full-content h3 {
-  margin: 0.5em 0 0.2em;
   font-size: 2.8rem;
-  font-weight: 700;
 }
 
 @media (max-width: 500px) {
   .post-full-content h3 {
-    font-size: 2.2rem;
+    font-size: 2.6rem;
   }
 }
 
 .post-full-content h4 {
-  margin: 0.5em 0 0.2em;
-  font-size: 2.8rem;
-  font-weight: 700;
+  font-size: 2.6rem;
 }
 
 @media (max-width: 500px) {
   .post-full-content h4 {
-    font-size: 2.2rem;
+    font-size: 2.4rem;
   }
 }
 
 .post-full-content h5 {
-  display: block;
-  margin: 0.5em 0;
-  padding: 1em 0 1.5em;
-  border: 0;
-  color: var(--dark-blue);
-  font-family: 'Lato', sans-serif;
-  font-display: swap;
-  font-size: 3.2rem;
-  line-height: 1.35em;
-  text-align: center;
-}
-
-@media (min-width: 1180px) {
-  .post-full-content h5 {
-    max-width: 1060px;
-    width: 100vw;
-  }
+  font-size: 2.4rem;
 }
 
 @media (max-width: 500px) {
   .post-full-content h5 {
-    padding: 0 0 0.5em;
     font-size: 2.2rem;
   }
 }
 
 .post-full-content h6 {
-  margin: 0.5em 0 0.2em;
-  font-size: 2.3rem;
-  font-weight: 700;
+  font-size: 2.2rem;
 }
 
 @media (max-width: 500px) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Currently there are some styles which seem to be from the Casper theme that are affecting `h5` headings. Here's what it looks like in a [recently published article](https://www.freecodecamp.org/news/markdown-cheatsheet/):

![image](https://user-images.githubusercontent.com/2051070/186341289-32a16ddb-0065-41a2-af22-83e9459090f7.png)

The changes here consolidate some of the styles for headings in post bodies, and normalizes the margins.

It also tweaks the styling a bit for smaller screens so that the font size of each heading is smaller than the one before it.

Here are the current font sizes:

| Heading | Desktop | Mobile |
|---------|---------|--------|
| h1      | 4.6rem  | 2.8rem |
| h2      | 3.6rem  | 2.6rem |
| h3      | 2.8rem  | 2.2rem |
| h4      | 2.8rem  | 2.2rem |
| h5      | 2.3rem  | 2rem   |
| h6      | 2.3rem  | 2rem   |

And here they are after the update:

| Heading | Desktop | Mobile |
|---------|---------|--------|
| h1      | 4.6rem  | 3.2rem |
| h2      | 3.6rem  | 3rem   |
| h3      | 2.8rem  | 2.6rem |
| h4      | 2.6rem  | 2.4rem |
| h5      | 2.4rem  | 2.2rem |
| h6      | 2.2rem  | 2rem   |

Also, here's a screenshot of the same portion of that article after the changes:

![image](https://user-images.githubusercontent.com/2051070/186346398-fa2d96a6-3bfe-4219-8fbb-53f01b4a8d3a.png)