### PR TITLE
fix: ad sizing

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2372,14 +2372,17 @@ a.banner:hover span {
   display: none; /* Hide ads by default for authenticated readers */
   background-color: var(--gray05);
   text-align: center;
+  padding: 10px;
+}
+
+.ad-container ins {
   min-width: 300px;
   min-height: 250px;
   max-width: 336px;
   max-height: 280px;
-  padding: 10px;
 }
 
-.ad-container.banner {
+.ad-container.banner ins {
   min-width: 100%;
 }
 

--- a/utils/ghost/modify-ghost-html.js
+++ b/utils/ghost/modify-ghost-html.js
@@ -18,6 +18,7 @@ const generateAdHTML = type => {
     ).toUpperCase()}</span>
     <ins
         class="adsbygoogle"
+        style="display: block;"
         data-ad-client="${googleAdsenseDataAdClient}"
         data-ad-slot="${googleAdsenseDataAdSlot}"
     ></ins>


### PR DESCRIPTION
…ad container directly

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This quick fix applies width and height directly to the `ins` ad containers, rather than just the grey wrappers around the ads.

This may prevent the 400 errors we're currently seeing.