### PR TITLE
fix: allow wider range of ads

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2377,13 +2377,15 @@ a.banner:hover span {
 
 .ad-container ins {
   min-width: 300px;
+  max-width: 740px; /* Max width of main content area */
+  width: 100%;
   min-height: 250px;
-  max-width: 336px;
-  max-height: 280px;
+  max-height: 480px; /* Consider increasing to 600px to allow half page unit ads */
+  height: 100%;
 }
 
 .ad-container.banner ins {
-  min-width: 100%;
+  min-width: 100%; /* Enables larger banner size of ~1020 x 250 */
 }
 
 /* Apply the following styles for unauthenticated readers */

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2373,19 +2373,15 @@ a.banner:hover span {
   background-color: var(--gray05);
   text-align: center;
   padding: 10px;
-}
-
-.ad-container ins {
-  min-width: 300px;
-  max-width: 740px; /* Max width of main content area */
+  min-width: 336px;
+  max-width: 740px; /* Max width of inner main content area */
   width: 100%;
-  min-height: 250px;
+  min-height: 280px;
   max-height: 480px; /* Consider increasing to 600px to allow half page unit ads */
-  height: 100%;
 }
 
-.ad-container.banner ins {
-  min-width: 100%; /* Enables larger banner size of ~1020 x 250 */
+.ad-container.banner {
+  min-width: 100%;
 }
 
 /* Apply the following styles for unauthenticated readers */

--- a/utils/ghost/modify-ghost-html.js
+++ b/utils/ghost/modify-ghost-html.js
@@ -10,6 +10,9 @@ const {
 } = require('../../config');
 
 const generateAdHTML = type => {
+  // Note: data-full-width-responsive is set to false to prevent ads from
+  // overflowing their containers. This can work for ads in the body of the
+  // article, but doesn't look good for the banner at the bottom of the page.
   return `<div class="ad-container ${
     type === 'banner' ? 'banner' : ''
   }" data-test-label="ad-container">
@@ -21,6 +24,8 @@ const generateAdHTML = type => {
         style="display: block;"
         data-ad-client="${googleAdsenseDataAdClient}"
         data-ad-slot="${googleAdsenseDataAdSlot}"
+        data-ad-format="auto"
+        data-full-width-responsive="false"
     ></ins>
     <script>
       window.addEventListener('load', () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

These tweaks should allow us to serve a wider range of ads throughout our articles based on display size and ad availability.

This should be flexible enough to allow ads to be up to 740 x 480 pixels within article bodies, and for the bottom banner to be around 1020 x 480 pixels.

Because it's not possible to fully test these changes locally, it would be better to block this and test with a couple of builds for non-English News sites. If that works, this can be merged for English News.