### PR TITLE
feat: add login to Docker step for Cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -54,6 +54,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
       - name: Start Ghost containers
         run: npm run start:containers
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Recently we had an issue with CI builds failing during the `Start Ghost containers` step: https://github.com/freeCodeCamp/news/runs/8073141156

That was probably because DockerHub now limits the number of image downloads or pulls. Currently, the limit is 100 pulls for anonymous users every 6 hours, and 200 for authenticated users with free accounts: https://docs.docker.com/docker-hub/download-rate-limit/#what-is-the-download-rate-limit-on-docker-hub

This change should allow us up to 200 pulls from DockerHub every 6 hours.

If we start to hit the 200 pulls limit, we could look at other optimizations like only running the Cypress action for PRs with specific activity types like `opened`, `reopened`, `synchronize`, and `ready_for_review`. This blog post has a pretty good overview, though I don't think we'll need to optimize as much as they did: https://engineering.leanix.net/blog/halve-your-github-actions-bill/