### PR TITLE
feat: enable german news builds

### DIFF
--- a/.github/workflows/deploy-eng.yml
+++ b/.github/workflows/deploy-eng.yml
@@ -8,7 +8,7 @@
 #
 #-------------------------------------------------
 
-name: Build and Deploy English News to Azure
+name: Eng - Build and Deploy
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-i18n.yml
+++ b/.github/workflows/deploy-i18n.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy Localized News to Azure
+name: i18n - Build and Deploy
 
 on:
   workflow_dispatch:
@@ -157,6 +157,7 @@ jobs:
             chinese,
             espanol,
             french,
+            german,
             italian,
             japanese,
             korean,

--- a/.github/workflows/deploy-i18n.yml
+++ b/.github/workflows/deploy-i18n.yml
@@ -21,6 +21,7 @@ jobs:
             chinese,
             espanol,
             french,
+            german,
             italian,
             japanese,
             korean,
@@ -59,6 +60,10 @@ jobs:
       FRENCH_GHOST_API_URL: ${{ secrets.FRENCH_GHOST_API_URL }}
       FRENCH_GHOST_API_VERSION: ${{ secrets.FRENCH_GHOST_API_VERSION }}
       FRENCH_GHOST_CONTENT_API_KEY: ${{ secrets.FRENCH_GHOST_CONTENT_API_KEY }}
+
+      GERMAN_GHOST_API_URL: ${{ secrets.GERMAN_GHOST_API_URL }}
+      GERMAN_GHOST_API_VERSION: ${{ secrets.GERMAN_GHOST_API_VERSION }}
+      GERMAN_GHOST_CONTENT_API_KEY: ${{ secrets.GERMAN_GHOST_CONTENT_API_KEY }}
 
       ITALIAN_GHOST_API_URL: ${{ secrets.ITALIAN_GHOST_API_URL }}
       ITALIAN_GHOST_API_VERSION: ${{ secrets.ITALIAN_GHOST_API_VERSION }}


### PR DESCRIPTION
This PR creates and enables the German JAMStack-news instances. The first commit creates the config required to build and push the image to Azure Container Registry. Once we have the first image, the second commit was created to enable deployments from the said image from the ACR to Azure App Service Plan for Web Containers.