### PR TITLE
fix: modify codeowners to properly handle i18n prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,15 @@ package-lock.json
 
 /package.json
 /package-lock.json
+
+# -------------------------------------------------
+# Exception for i18n PRs
+# -------------------------------------------------
+
+/config/i18n/locales/**/*.json @freecodecamp/i18n
+
+# -------------------------------------------------
+# Revert override for English because codeowners
+# doesn't support negation?
+# -------------------------------------------------
+/config/i18n/locales/english/*.json @freecodecamp/dev-team


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Reading the documentation, Codeowners supports wildcards `**` but does not support negation `!`.

So in theory, this should assign Crowdin PRs to the i18n team, while keeping the **English** source PRs on the dev team radar?