### PR TITLE
fix: remove original locale translations

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -57,21 +57,6 @@ module.exports = function (config) {
 
     // Remove ads.txt from Chinese build
     if (currentLocale_i18n === 'chinese') unlinkSync('./dist/ads.txt');
-
-    // Write translated locales for the current build language to the assets directory
-    // as a workaround to display those strings in search-results.js instead of with the
-    // translation shortcode
-    const currLocaleTranslationsPath = `./config/i18n/locales/${currentLocale_i18n}/translations.json`;
-    const translationsObj = JSON.parse(
-      readFileSync(currLocaleTranslationsPath, { encoding: 'utf-8' })
-    );
-    const translatedLocales =
-      translationsObj['original-author-translator'].locales;
-
-    writeFileSync(
-      './dist/assets/translated-locales.json',
-      JSON.stringify(translatedLocales)
-    );
   });
 
   // RSS and AMP plugins

--- a/config/i18n/locales/english/translations.json
+++ b/config/i18n/locales/english/translations.json
@@ -44,26 +44,12 @@
   "learn-to-code-cta": "Learn to code for free. freeCodeCamp's open source curriculum has helped more than 40,000 people get jobs as developers. {{ <0> }}Get started{{ </0> }}",
   "original-author-translator": {
     "roles": {
-      "author": "Author: {{ name }} ({{ locale }})",
+      "author": "Author: {{ name }}",
       "translator": "Translator: {{ name }}"
     },
     "details": {
       "original-article": "{{ <0> }}Original article:{{ </0> }} {{ title }} by {{ author }}",
       "translated-by": "{{ <0> }}Translated by:{{ </0> }} {{ translator }}"
-    },
-    "locales": {
-      "arabic": "Arabic",
-      "bengali": "Bengali",
-      "chinese": "Chinese",
-      "english": "English",
-      "espanol": "Spanish",
-      "french": "French",
-      "italian": "Italian",
-      "japanese": "Japanese",
-      "korean": "Korean",
-      "portuguese": "Portuguese",
-      "swahili": "Swahili",
-      "urdu": "Urdu"
     }
   },
   "embed-title": "Embedded content",

--- a/cypress/e2e/espanol/amp/amp.cy.js
+++ b/cypress/e2e/espanol/amp/amp.cy.js
@@ -18,8 +18,8 @@ describe('AMP page', () => {
       cy.get(selectors.AMPAuthorHeader).children().should('have.length', 2);
     });
 
-    it("the AMP Author element should contain the author's name and the locale of the original article", () => {
-      cy.get(selectors.AMPAuthor).contains('Quincy Larson (inglés)');
+    it("the AMP Author element should contain the author's name", () => {
+      cy.get(selectors.AMPAuthor).contains('Quincy Larson');
     });
 
     it("the AMP Translator element should contain the translator's name", () => {

--- a/cypress/e2e/espanol/landing/landing.cy.js
+++ b/cypress/e2e/espanol/landing/landing.cy.js
@@ -65,13 +65,13 @@ describe('Landing', () => {
         });
     });
 
-    it("the author list item's profile link should contain the author's name and the locale of the original article", () => {
+    it("the author list item's profile link should contain the author's name", () => {
       cy.get(selectors.postCard)
         .contains(selectors.translatedArticleTitle)
         .parentsUntil('article')
         .find(selectors.authorListItem)
         .find(selectors.profileLink)
-        .contains(`${selectors.authorName} (inglés)`);
+        .contains(`${selectors.authorName}`);
     });
 
     it("the author list item's profile link should be a full URL that points to the original author's page", () => {

--- a/cypress/e2e/espanol/post/post.cy.js
+++ b/cypress/e2e/espanol/post/post.cy.js
@@ -41,10 +41,10 @@ describe('Post', () => {
           });
       });
 
-      it("the author card's profile link should contain the author's name and the locale of the original article", () => {
+      it("the author card's profile link should contain the author's name", () => {
         cy.get(selectors.authorHeaderNoBio)
           .find(selectors.authorCard)
-          .contains(`${selectors.authorName} (inglés)`);
+          .contains(`${selectors.authorName}`);
       });
 
       it("the author card's profile link should be a full URL that points to the original author's page", () => {
@@ -103,10 +103,10 @@ describe('Post', () => {
           });
       });
 
-      it("the author card should contain the author's name and the locale of the original article", () => {
+      it("the author card should contain the author's name", () => {
         cy.get(selectors.authorHeaderWithBio)
           .find(selectors.authorCard)
-          .contains(`${selectors.authorName} (inglés)`);
+          .contains(`${selectors.authorName}`);
       });
 
       it("the author card's profile link should be a full URL that points to the original author's page", () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/news/pull/442

<!-- Feel free to add any additional description of changes below this line -->
This PR includes the minimum required changes to remove the text showing the original article's locale from translated articles.

Here are some screenshots showing the future changes for the Spanish publication:

- Landing page: ![image](https://user-images.githubusercontent.com/2051070/193268018-6bfed763-6e03-4e80-af2f-ad18222571e2.png)

- Top byline: ![image](https://user-images.githubusercontent.com/2051070/193268109-cc65842e-2f0c-4950-8921-da26b87cdb08.png)

- Bottom byline with bio: ![image](https://user-images.githubusercontent.com/2051070/193268158-27f586e0-80d2-4c91-a844-a9138478398f.png)

- AMP page byline: ![image](https://user-images.githubusercontent.com/2051070/193268338-6a4a5149-0af1-4174-916f-8a57cb3c2178.png)

By removing this feature in separate PRs, we don't have to rush to get all the different `translation.json` files, which are now managed on CrowdIn, in sync between builds.

Once this is merged, translators and proofreaders can take their time approving the changes, and builds can continue even if the files our out of sync for a period of time.

If a particular `translation.json` file still has the `original-author-translator.locales` object and `original-author-translator.roles.author` string, translated articles will still show the original article's locale like they do now.

Once all the different `translation.json` files are in sync and downloaded back to this repo, then https://github.com/freeCodeCamp/news/pull/442 should be ready for review.