### PR TITLE
fix: conditional ad layout styling

### DIFF
--- a/cypress/e2e/chinese/post/ads.cy.js
+++ b/cypress/e2e/chinese/post/ads.cy.js
@@ -22,4 +22,8 @@ describe('Ads', () => {
   it('the post should not include any ad containers', () => {
     cy.get(selectors.adContainer).should('not.exist');
   });
+
+  it('the post should not use the ad layout', () => {
+    cy.get('.ad-layout').should('not.exist');
+  });
 });

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -14,7 +14,7 @@ time #}
 
 {% block content %}
     <main id="site-main" class="post-template site-main outer">
-        <div class="inner ad-layout">
+        <div class="inner {{ "ad-layout" if (adsEnabled) }}">
             <article class="post-full post {{ "no-image" if not (post.feature_image) }}">
                 <header class="post-full-header">
                     <section class="post-full-meta">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This fix will apply the ad layout styling conditionally, and will prevent them from being applied when the global flag is set to false (`ADS_ENABLED=false`), or for Chinese News where ads aren't enabled.

Before this fix:

![image](https://user-images.githubusercontent.com/2051070/193735141-4164d6e7-a6d7-4e08-81f8-05d13f1c6a1b.png)

After this fix:

![image](https://user-images.githubusercontent.com/2051070/193735236-e037a008-8437-41aa-b445-49879f583df2.png)

