### PR TITLE
fix(test): downgrade firefox for CI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -42,6 +42,14 @@ jobs:
       LOCALE_FOR_GHOST: ${{ matrix.languages }}
 
     steps:
+      # Remove this step after firefox launches 106 (hopefully it's fixed by then)
+      - name: Downgrade Firefox
+        run: |
+          curl https://ftp.mozilla.org/pub/firefox/releases/103.0/linux-x86_64/en-US/firefox-103.0.tar.bz2 --output firefox-103.0.tar.bz2
+          tar -xjf firefox-103.0.tar.bz2
+          sudo mv firefox /opt/
+          sudo mv /usr/bin/firefox /usr/bin/firefox_old
+          sudo ln -s /opt/firefox/firefox /usr/bin/firefox
       - name: Checkout source files
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
 


### PR DESCRIPTION
Why it's failing is unclear, but version 103 seems fine.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
