### PR TITLE
fix: search results page empty query

### DIFF
--- a/src/_data/secrets.js
+++ b/src/_data/secrets.js
@@ -5,7 +5,8 @@ const {
   adsEnabled,
   eleventyEnv,
   googleAdsenseDataAdClient,
-  googleAdsenseDataAdSlot
+  googleAdsenseDataAdSlot,
+  postsPerPage
 } = require('../../config');
 
 module.exports = {
@@ -15,5 +16,6 @@ module.exports = {
   adsEnabled,
   eleventyEnv,
   googleAdsenseDataAdClient,
-  googleAdsenseDataAdSlot
+  googleAdsenseDataAdSlot,
+  postsPerPage
 };

--- a/src/_includes/assets/js/search-results.js
+++ b/src/_includes/assets/js/search-results.js
@@ -1,6 +1,6 @@
 document.addEventListener('DOMContentLoaded', async () => {
   const urlParams = new URLSearchParams(window.location.search);
-  const queryStr = urlParams.get('query');
+  const queryStr = urlParams.get('query') || '';
   const postFeed = document.querySelector('.post-feed');
   let currPage = 0;
 

--- a/src/_includes/assets/js/search-results.js
+++ b/src/_includes/assets/js/search-results.js
@@ -2,6 +2,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const urlParams = new URLSearchParams(window.location.search);
   const queryStr = urlParams.get('query') || '';
   const postFeed = document.querySelector('.post-feed');
+  const postsPerPage = Number('{{ secrets.postsPerPage }}');
   let currPage = 0;
 
   const getHits = async pageNo => {
@@ -21,7 +22,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       return index
         .search({
           query: queryStr,
-          hitsPerPage: 15,
+          hitsPerPage: postsPerPage,
           page: pageNo
         })
         .then(({ hits } = {}) => {
@@ -247,11 +248,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       postFeed.appendChild(generateCardNode(hit, lazyLoad));
     });
 
-    // Only render "Load More Articles" button
-    // if there are more than 15 hits, meaning
-    // that there are up to 15 more hits in the
-    // next API call
-    if (hits.length === 15) {
+    // Only show the "Load More Articles" button if the number of
+    // returned hits is equal to postsPerPage, meaning that there
+    // are probably more hits to load on the next API call
+    if (hits.length === postsPerPage) {
       // Check for existing button and render if none exists
       document.querySelector('#readMoreBtn') ? '' : renderLoadMoreBtn();
     } else {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Currently the search results page is pretty unpredictable when there is no search query.

On the search results page for English News, 15 of the most recently index articles are shown when there's no search query: https://www.freecodecamp.org/news/search/

But for other languages like Arabic, only two articles are shown: https://www.freecodecamp.org/arabic/news/search/

This PR fixes that by passing an empty string instead of `null` to Algolia. This causes Algolia to return the most recently added articles for that index:

![Screen Shot 2022-10-21 at 5 30 56 PM](https://user-images.githubusercontent.com/2051070/197150733-285ada6c-99c2-444b-b2f6-1ba9aa5da7b3.jpg)

This PR also sets the number of hits to `postsPerPage`, so a search query will show up to 25 hits like we do on the landing page.