### PR TITLE
fix: remove redundant author translator info from code, update tests

### DIFF
--- a/config/i18n/locales/english/translations.json
+++ b/config/i18n/locales/english/translations.json
@@ -51,7 +51,8 @@
       "translator": "Translator: {{ name }}"
     },
     "details": {
-      "original-article": "{{ <0> }}Original article:{{ </0> }} {{ title }}"
+      "original-article": "{{ <0> }}Original article:{{ </0> }} {{ title }} by {{ author }}",
+      "translated-by": "{{ <0> }}Translated by:{{ </0> }} {{ translator }}"
     },
     "locales": {
       "arabic": "Arabic",

--- a/cypress/e2e/espanol/post/post.cy.js
+++ b/cypress/e2e/espanol/post/post.cy.js
@@ -7,9 +7,8 @@ const selectors = {
   profileLink: "[data-test-label='profile-link']",
   authorBio: "[data-test-label='author-bio']",
   translatorBio: "[data-test-label='translator-bio']",
-  authorIntro: "[data-test-label='author-intro']",
-  originalArticle: "[data-test-label='original-article']",
-  translatorIntro: "[data-test-label='translator-intro']",
+  translationIntro: "[data-test-label='translation-intro']",
+  originalArticleLink: "[data-test-label='original-article-link']",
   authorName: 'Quincy Larson',
   translatorName: 'Rafael D. Hernandez'
 };

--- a/cypress/e2e/espanol/post/post.cy.js
+++ b/cypress/e2e/espanol/post/post.cy.js
@@ -167,14 +167,14 @@ describe('Post', () => {
 
     context('Translated article intro', () => {
       it('the author intro should contain links to the original article', () => {
-        cy.get(selectors.authorIntro).then($el => {
-          cy.wrap($el).find(selectors.originalArticle);
+        cy.get(selectors.translationIntro).then($el => {
+          cy.wrap($el).find(selectors.originalArticleLink);
         });
       });
 
       it('the link to the original article should contain the expected text and `href` attribute', () => {
-        cy.get(selectors.authorIntro)
-          .find(selectors.originalArticle)
+        cy.get(selectors.translationIntro)
+          .find(selectors.originalArticleLink)
           .then($el => {
             cy.wrap($el).contains(
               'The #100DaysOfCode Challenge, its history, and why you should try it for 2021'

--- a/utils/ghost/original-post-handler.js
+++ b/utils/ghost/original-post-handler.js
@@ -51,28 +51,26 @@ const originalPostHandler = async post => {
         locale_i18n: originalPostLocale
       };
 
-      const authorEl = translate(
+      const originalArticleHTML = translate(
         'original-author-translator.details.original-article',
         {
           '<0>': '<strong>',
           '</0>': '</strong>',
-          title: `<a href="${originalPost.url}" target="_blank" rel="noopener noreferrer" data-test-label="original-article">${originalPost.title}</a>`,
+          title: `<a href="${originalPost.url}" target="_blank" rel="noopener noreferrer" data-test-label="original-article-link">${originalPost.title}</a>`,
           interpolation: {
             escapeValue: false
           }
         }
       );
 
-      const introEl = `
-        <p>
-          <span data-test-label="author-intro">
-            ${authorEl}
-          </span>
+      const introHTML = `
+        <p data-test-label="translation-intro">
+          ${originalArticleHTML}
         </p>`;
 
       // Append details about the original article
       // to the beginning of the translated article
-      post.html = introEl + post.html;
+      post.html = introHTML + post.html;
     } catch (err) {
       console.warn(`
       ---------------------------------------------------------------

--- a/utils/ghost/original-post-handler.js
+++ b/utils/ghost/original-post-handler.js
@@ -1,6 +1,5 @@
 const { URL } = require('url');
 const { allGhostAPIInstances } = require('./api');
-const { computedPath } = require('../../config');
 const getImageDimensions = require('../get-image-dimensions');
 const translate = require('../translate');
 
@@ -58,21 +57,6 @@ const originalPostHandler = async post => {
           '<0>': '<strong>',
           '</0>': '</strong>',
           title: `<a href="${originalPost.url}" target="_blank" rel="noopener noreferrer" data-test-label="original-article">${originalPost.title}</a>`,
-          author: `<a href="${originalPost.primary_author.url}" target="_blank" rel="noopener noreferrer" data-test-label="profile-link">${originalPost.primary_author.name}</a>`,
-          interpolation: {
-            escapeValue: false
-          }
-        }
-      );
-
-      const translatorEl = translate(
-        'original-author-translator.details.translated-by',
-        {
-          '<0>': '<strong>',
-          '</0>': '</strong>',
-          translator: `<a href="/${
-            computedPath + post.primary_author.path
-          }" data-test-label="profile-link">${post.primary_author.name}</a>`,
           interpolation: {
             escapeValue: false
           }
@@ -84,14 +68,10 @@ const originalPostHandler = async post => {
           <span data-test-label="author-intro">
             ${authorEl}
           </span>
-          <br><br>
-          <span data-test-label="translator-intro">
-            ${translatorEl}
-          </span>
         </p>`;
 
-      // Append details about the original article / author and translator
-      // to the beginning of the article
+      // Append details about the original article
+      // to the beginning of the translated article
       post.html = introEl + post.html;
     } catch (err) {
       console.warn(`


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #519

<!-- Feel free to add any additional description of changes below this line -->

This is related to #541, and should be reviewed and merged once the `original-author-translator.details` object of the `translation.json` files for the following locales are in sync with the English file:

- [x] Arabic
- [ ] ~~Bengali~~ (Doesn't use the original author / translator feature)
- [x] Chinese
- [x] Espanol
- [ ] ~~French~~ (Not synced automatically - see note below)
- [x] German
- [ ] ~~Indonesian~~ (Not synced automatically - see note below)
- [x] Italian
- [x] Japanese
- [ ] ~~Korean~~ (Not synced automatically - see note below)
- [x] Portuguese
- [ ] ~~Swahili~~ (Not synced automatically - see note below)
- [x] Ukrainian
- [ ] ~~Urdu~~ (Not synced automatically - see note below)

Note: Locales that aren't synced automatically will render `...by {{ author }}` until #546 is merged, that job runs, and the `translation.json` files for those locales are merged.

But I think it would be okay for this to get in before #546 since there are already other issues related to the `translation.json` files for the locales with strikethroughs not being synced. This should at least fix the issues for the publications that are checked off above.