### PR TITLE
fix: remove redundant info from translation.json file

### DIFF
--- a/config/i18n/locales/english/translations.json
+++ b/config/i18n/locales/english/translations.json
@@ -51,8 +51,7 @@
       "translator": "Translator: {{ name }}"
     },
     "details": {
-      "original-article": "{{ <0> }}Original article:{{ </0> }} {{ title }} by {{ author }}",
-      "translated-by": "{{ <0> }}Translated by:{{ </0> }} {{ translator }}"
+      "original-article": "{{ <0> }}Original article:{{ </0> }} {{ title }}"
     },
     "locales": {
       "arabic": "Arabic",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #519 and #540

<!-- Feel free to add any additional description of changes below this line -->
This is the first step in removing the redundant original author and translator information mentioned in #519.

Once this is in, translation leads can take their time while syncing their language's `translation.json` files. If one publication takes a bit longer, the data for the original author's name and the translator will still be sourced during the build, and the text / links should still render properly instead of showing i18n keys.

Once the `translation.json` files are synced for all the active publications (tracked in #540), we can review and merge #540 which simplifies the code and updates the tests.