### PR TITLE
fix: run Crowdin downloads in sequence

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     strategy:
+      max-parallel: 1
       matrix:
         languages:
           - name: Arabic


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
The scheduled Crowdin Download action seems to be failing because multiple downloads are being run in parallel, but it seems like Crowdin requires downloads to run one at a time: https://github.com/freeCodeCamp/news/actions/runs/4015528503/jobs/6897360785#step:5:37

This should make the reusable download workflow run in sequence and prevent multiple downloads from triggering at the same time.