### PR TITLE
chore: remove languages from builds

### DIFF
--- a/.github/workflows/deploy-i18n.yml
+++ b/.github/workflows/deploy-i18n.yml
@@ -20,13 +20,10 @@ jobs:
             chinese,
             espanol,
             french,
-            german,
-            indonesian,
             italian,
             japanese,
             korean,
             portuguese,
-            swahili,
             ukrainian,
             urdu
           ]
@@ -165,13 +162,10 @@ jobs:
             chinese,
             espanol,
             french,
-            german,
-            indonesian,
             italian,
             japanese,
             korean,
             portuguese,
-            swahili,
             ukrainian,
             urdu
           ]


### PR DESCRIPTION
This PR drops Swahili, German and Indonesian from the builds
