### PR TITLE
feat: update to Prism v1.29.0

### DIFF
--- a/src/_includes/partials/prism.njk
+++ b/src/_includes/partials/prism.njk
@@ -1,72 +1,33 @@
-<link rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'" href="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism.min.css" />
-<noscript><link rel="stylesheet" href="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism.min.css"></noscript>
-<link rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'"
-    href="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-unescaped-markup.css" />
-<noscript><link rel="stylesheet" href="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-unescaped-markup.css"></noscript>
+<link
+  rel="preload"
+  as="style"
+  onload="this.onload=null;this.rel='stylesheet'"
+  href="https://cdn.freecodecamp.org/news-assets/prism/1.29.0/themes/prism.min.css"
+/>
+<noscript>
+  <link
+    rel="stylesheet"
+    href="https://cdn.freecodecamp.org/news-assets/prism/1.29.0/themes/prism.min.css"
+  />
+</noscript>
+<link
+  rel="preload"
+  as="style"
+  onload="this.onload=null;this.rel='stylesheet'"
+  href="https://cdn.freecodecamp.org/news-assets/prism/1.29.0/plugins/unescaped-markup/prism-unescaped-markup.min.css"
+/>
+<noscript>
+  <link
+    rel="stylesheet"
+    href="https://cdn.freecodecamp.org/news-assets/prism/1.29.0/plugins/unescaped-markup/prism-unescaped-markup.min.css"
+  />
+</noscript>
 
-<script defer type="text/javascript" src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-unescaped-markup.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-markup-templating.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-bash.min.js"></script>
-<script defer type="text/javascript" src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-c.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-clojure.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-cpp.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-csharp.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-css.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-docker.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-elixir.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-erlang.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-git.min.js"></script>
-<script defer type="text/javascript" src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-go.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-graphql.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-haskell.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-java.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-javascript.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-json.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-jsx.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-julia.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-kotlin.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-lua.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-markup.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-php.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-python.min.js"></script>
-<script defer type="text/javascript" src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-r.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-ruby.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-rust.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-scala.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-sql.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-swift.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-typescript.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-yaml.min.js"></script>
-<script defer type="text/javascript"
-    src="https://cdn.freecodecamp.org/news-assets/prism-1-16-0/prism-dart.min.js"></script>
+<script
+  defer
+  src="https://cdn.freecodecamp.org/news-assets/prism/1.29.0/components/prism-core.min.js"
+></script>
+<script
+  defer
+  src="https://cdn.freecodecamp.org/news-assets/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"
+></script>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/news/issues/602

<!-- Feel free to add any additional description of changes below this line -->
This updates `prism.njk` so we use v1.29.0 to fix the issue above. It also simplifies things quite a bit by using Prism's Autoloader plugin to automatically load the correct syntax highlighting files from our CDN.

Update: Just tested this locally and the Autoloader plugin seems to work as expected, and loads the correct files for syntax highlighting from our CDN.

For example, after doing a local build of the Spanish publication, the "La función length en Python: Cómo averiguar el tamaño de una lista" article ([localhost](http://localhost:8080/espanol/news/la-funcion-length-en-python-como-averiguar-el-tamano-de-una-lista/), [live](https://www.freecodecamp.org/espanol/news/la-funcion-length-en-python-como-averiguar-el-tamano-de-una-lista/)) loads the following Prism resources from our CDN:

![image](https://user-images.githubusercontent.com/2051070/229430676-30a91ce6-1c5a-48e3-b883-85cda4dc6cb5.png)

Also, the bugs mentioned in https://github.com/freeCodeCamp/news/issues/602 appear to be resolved. Even with the deferred and asynchronously fetched Prism scripts by the Autoloader plugin, syntax highlighting is correctly applied after both regular and hard refreshes of the page.