### PR TITLE
feat: show URL as link when unable to fetch original post

### DIFF
--- a/utils/ghost/original-post-handler.js
+++ b/utils/ghost/original-post-handler.js
@@ -12,8 +12,13 @@ const originalPostHandler = async post => {
   const match = originalPostRegex.exec(headAndFootCode);
 
   if (match) {
+    let href_value = '';
+    let link_text = '';
+
     try {
       const { pathname } = new URL(match.groups.url);
+      console.log('pathname', pathname);
+      console.log('match.groups.url', match.groups.url);
       // Currently, pathSegments is length 2 for English and Chinese
       // ( ['news', 'slug'] ), and length 3 for other locales
       // ( ['locale', 'news', 'slug'] )
@@ -51,26 +56,9 @@ const originalPostHandler = async post => {
         locale_i18n: originalPostLocale
       };
 
-      const originalArticleHTML = translate(
-        'original-author-translator.details.original-article',
-        {
-          '<0>': '<strong>',
-          '</0>': '</strong>',
-          title: `<a href="${originalPost.url}" target="_blank" rel="noopener noreferrer" data-test-label="original-article-link">${originalPost.title}</a>`,
-          interpolation: {
-            escapeValue: false
-          }
-        }
-      );
-
-      const introHTML = `
-        <p data-test-label="translation-intro">
-          ${originalArticleHTML}
-        </p>`;
-
-      // Append details about the original article
-      // to the beginning of the translated article
-      post.html = introHTML + post.html;
+      // Use the title of the original post as link text
+      href_value = originalPost.url;
+      link_text = originalPost.title;
     } catch (err) {
       console.warn(`
       ---------------------------------------------------------------
@@ -81,7 +69,32 @@ const originalPostHandler = async post => {
       post has not been deleted.
       ---------------------------------------------------------------
       `);
+
+      // Use URL in the script tag as link text
+      href_value = match.groups.url;
+      link_text = match.groups.url;
     }
+
+    const originalArticleHTML = translate(
+      'original-author-translator.details.original-article',
+      {
+        '<0>': '<strong>',
+        '</0>': '</strong>',
+        title: `<a href="${href_value}" target="_blank" rel="noopener noreferrer" data-test-label="original-article-link">${link_text}</a>`,
+        interpolation: {
+          escapeValue: false
+        }
+      }
+    );
+
+    const introHTML = `
+      <p data-test-label="translation-intro">
+        ${originalArticleHTML}
+      </p>`;
+
+    // Append details about the original article
+    // to the beginning of the translated article
+    post.html = introHTML + post.html;
   }
 
   return post;

--- a/utils/ghost/original-post-handler.js
+++ b/utils/ghost/original-post-handler.js
@@ -12,8 +12,8 @@ const originalPostHandler = async post => {
   const match = originalPostRegex.exec(headAndFootCode);
 
   if (match) {
-    let href_value = '';
-    let link_text = '';
+    let hrefValue = '';
+    let linkText = '';
 
     try {
       const { pathname } = new URL(match.groups.url);
@@ -55,8 +55,8 @@ const originalPostHandler = async post => {
       };
 
       // Use the title of the original post as link text
-      href_value = originalPost.url;
-      link_text = originalPost.title;
+      hrefValue = originalPost.url;
+      linkText = originalPost.title;
     } catch (err) {
       console.warn(`
       ---------------------------------------------------------------
@@ -69,8 +69,8 @@ const originalPostHandler = async post => {
       `);
 
       // Use URL in the script tag as link text
-      href_value = match.groups.url;
-      link_text = match.groups.url;
+      hrefValue = match.groups.url;
+      linkText = match.groups.url;
     }
 
     const originalArticleHTML = translate(
@@ -78,7 +78,7 @@ const originalPostHandler = async post => {
       {
         '<0>': '<strong>',
         '</0>': '</strong>',
-        title: `<a href="${href_value}" target="_blank" rel="noopener noreferrer" data-test-label="original-article-link">${link_text}</a>`,
+        title: `<a href="${hrefValue}" target="_blank" rel="noopener noreferrer" data-test-label="original-article-link">${linkText}</a>`,
         interpolation: {
           escapeValue: false
         }

--- a/utils/ghost/original-post-handler.js
+++ b/utils/ghost/original-post-handler.js
@@ -17,8 +17,6 @@ const originalPostHandler = async post => {
 
     try {
       const { pathname } = new URL(match.groups.url);
-      console.log('pathname', pathname);
-      console.log('match.groups.url', match.groups.url);
       // Currently, pathSegments is length 2 for English and Chinese
       // ( ['news', 'slug'] ), and length 3 for other locales
       // ( ['locale', 'news', 'slug'] )


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #621

<!-- Feel free to add any additional description of changes below this line -->

When failed to fetch the original post (show URL as a link):
![スクリーンショット 2023-04-28 220314](https://user-images.githubusercontent.com/25644062/235155596-ad6b869f-ab51-428e-9fe9-7ff113eee10a.png)

When successfully fetched the original post (show article title as a link):
![スクリーンショット 2023-04-28 220345](https://user-images.githubusercontent.com/25644062/235155615-344b1469-f170-40a9-82e9-5a8b5cf432ba.png)
