### PR TITLE
fix: show ads to all readers

### DIFF
--- a/src/_includes/partials/ad.njk
+++ b/src/_includes/partials/ad.njk
@@ -10,6 +10,6 @@
         data-full-width-responsive="true"
     ></ins>
     <script>
-        if (!isAuthenticated) (adsbygoogle = window.adsbygoogle || []).push({});
+        (adsbygoogle = window.adsbygoogle || []).push({});
     </script>
 </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
In #668, which enabled the layout to show ads to all readers whether they're authenticated or not, I missed a check in the `ad.njk` template file which would push Google ads code to each ad block only for non-authenticated readers.

Removing this check should mean that Google ads are loaded for each ad block for both authenticated and non-authenticated readers.