### PR TITLE
chore: disable schedule on i18n branches

### DIFF
--- a/.github/workflows/deploy-i18n.yml
+++ b/.github/workflows/deploy-i18n.yml
@@ -2,8 +2,8 @@ name: i18n - Build and Deploy
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 0/6 * * *' # Build once every six hours
+  # schedule:
+  #  - cron: '0 0/6 * * *' # Build once every six hours
 
 jobs:
   build:


### PR DESCRIPTION
Disabling automatic publishing on all localized news instances over the weekend.