### PR TITLE
fix(docker,serve): use latest versions of serve

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:18-alpine
-RUN npm install -g --progress=false serve@13
+RUN npm install -g --progress=false serve
 
 ARG BUILD_LANGUAGE
 


### PR DESCRIPTION
This bumps the serve version so that we can get nice logs

- [ ] Need to check log rotation.
