### PR TITLE
chore: removed study group sentence

### DIFF
--- a/config/i18n/locales/portuguese/translations.json
+++ b/config/i18n/locales/portuguese/translations.json
@@ -69,7 +69,7 @@
   "embed-title": "Conteúdo incorporado",
   "footer": {
     "tax-exempt-status": "O freeCodeCamp é uma organização beneficente 501(c)(3), isenta de impostos e apoiada por doações (Número de identificação fiscal federal dos Estados Unidos: 82-0779546).",
-    "mission-statement": "Nossa missão: ajudar as pessoas a aprender a programar de forma gratuita. Conseguimos isto criando milhares de vídeos, artigos e lições de programação interativas, todas disponíveis gratuitamente para o público. Também temos milhares de grupos de estudo do freeCodeCamp em todo o mundo.",
+    "mission-statement": "Nossa missão: ajudar as pessoas a aprender a programar de forma gratuita. Conseguimos isto criando milhares de vídeos, artigos e lições de programação interativas, todas disponíveis gratuitamente para o público.",
     "donation-initiatives": "As doações feitas ao freeCodeCamp vão para nossas iniciativas educacionais e ajudam a pagar servidores, serviços e a equipe.",
     "donate-text": "Você pode fazer {{ <0> }}uma doação dedutível de impostos aqui{{ </0> }}.",
     "trending-guides": "Guias de tendências",


### PR DESCRIPTION
As requested I removed the sentence in Portuguese for"We also have thousands of freeCodeCamp study groups around the world." 

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

[Ref: #52259](https://github.com/freeCodeCamp/freeCodeCamp/issues/52259)

<!-- Feel free to add any additional description of changes below this line -->
