### PR TITLE
fix: sync footer html and css with main repo

### DIFF
--- a/config/i18n/locales/english/translations.json
+++ b/config/i18n/locales/english/translations.json
@@ -73,6 +73,7 @@
     "donation-initiatives": "Donations to freeCodeCamp go toward our education initiatives, and help pay for servers, services, and staff.",
     "donate-text": "You can {{ <0> }}make a tax-deductible donation here{{ </0> }}.",
     "trending-guides": "Trending Guides",
+    "mobile-app": "Mobile App",
     "our-nonprofit": "Our Charity",
     "links": {
       "about": "About",

--- a/cypress/e2e/english/landing/i18n.cy.js
+++ b/cypress/e2e/english/landing/i18n.cy.js
@@ -13,7 +13,8 @@ const selectors = {
     donateText: "[data-test-label='donate-text']",
     trendingGuides: "[data-test-label='trending-guides']",
     ourNonprofit: "[data-test-label='our-nonprofit']",
-    trendingGuideLinks: "[data-test-label='trending-guides'] a",
+    trendingGuideLinks:
+      "[data-test-label='trending-guides'] .trending-guides-articles a",
     links: {
       about: "[data-test-label='about']",
       alumni: "[data-test-label='alumni']",

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -1945,63 +1945,84 @@ pre.runkit-element {
 /* ---------------------------------------------------------- */
 
 .site-footer {
-  position: relative;
   color: var(--gray85);
   background: var(--gray05);
   line-height: 1.6;
-}
-
-.footer-container {
-  margin-right: auto;
-  margin-left: auto;
-  padding-left: 15px;
-  padding-right: 15px;
-  padding-top: 40px;
-  padding-bottom: 40px;
+  padding: 40px 15px;
   font-size: 16px;
-  overflow-x: hidden;
 }
 
-.footer-container p {
+.footer-top {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(30.5em, 1fr));
+}
+
+@media (max-width: 500px) {
+  .footer-top {
+    grid-template-columns: repeat(auto-fit, minmax(19em, 1fr));
+  }
+}
+
+.footer-top,
+.footer-bottom {
+  width: min(100%, 1300px);
+  margin-inline: auto;
+}
+
+.site-footer p {
   margin: 0 0 1.45rem;
   line-height: 30px;
+  font-size: 16px;
 }
 
-.footer-container a {
+.site-footer a {
   color: var(--gray85);
   text-decoration: none;
+  padding: 2px;
 }
 
-.footer-container .col-header {
-  flex: 0 0 100%;
-  padding-bottom: 15px;
+.site-footer a:hover {
+  text-decoration: underline;
+}
+
+.site-footer .col-header,
+.trending-guides .col-header {
+  text-align: center;
   font-weight: 700;
   font-size: 16px;
-  text-align: center;
   padding: 0 15px 15px;
+  margin-bottom: 0;
+}
+
+.trending-guides-articles {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(11em, 1fr));
+  grid-column-gap: 3rem;
+  grid-row-gap: 0.5rem;
+}
+
+@media (max-width: 1400px) {
+  .trending-guides-articles {
+    grid-template-columns: repeat(auto-fit, minmax(12em, 1fr));
+  }
+}
+
+@media (max-width: 800px) {
+  .trending-guides-articles {
+    grid-template-columns: repeat(auto-fit, minmax(13em, 1fr));
+  }
 }
 
 .footer-row {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
   margin: 0;
 }
 
 .footer-col {
-  display: flex;
-  flex-direction: column;
-  flex: 0 0 100%;
-  padding-left: 15px;
-  padding-right: 15px;
+  padding-inline: 15px;
   font-size: 16px;
-}
-
-.footer-right,
-.footer-left {
-  display: flex;
-  flex-direction: column;
-  flex: 0 0 100%;
 }
 
 .footer-col a {
@@ -2009,30 +2030,23 @@ pre.runkit-element {
 }
 
 .footer-desc-col {
-  flex: 1 0 90%;
-  display: flex;
-  flex-direction: column;
-  padding-left: 15px;
-  padding-right: 15px;
+  padding-inline: 15px;
   margin-bottom: 30px;
+  align-self: center;
 }
 
 .footer-desc-col a {
   text-decoration: underline;
+  padding: 2px;
 }
 
 p.footer-donation {
-  /* display: flex; */
   font-weight: 700;
   font-size: 18px;
 }
 
 p.footer-donation a:hover {
   text-decoration: none;
-}
-
-.footer-container .col-spacer {
-  margin-top: -3rem;
 }
 
 .trending-guides {
@@ -2051,54 +2065,14 @@ p.footer-donation a:hover {
 }
 
 @media (min-width: 500px) {
-  .trending-guides-row {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
-
-  .footer-col-3 {
-    flex: 1 0 100%;
-    flex-direction: row;
-  }
-
-  .footer-right {
-    padding-left: 15px;
-  }
-
-  .footer-col-1,
-  .footer-col-2,
-  .footer-right,
-  .footer-left {
-    flex: 1 0 45%;
-    height: auto;
+  .footer-col {
     font-size: 15;
   }
 }
 
 @media (min-width: 800px) {
-  .footer-container {
-    width: 750px;
-  }
-
-  .footer-col-1,
-  .footer-col-2,
-  .footer-col-3 {
-    flex: 1 0 25%;
-    height: auto;
+  .footer-col {
     font-size: 16.5;
-  }
-
-  .footer-col-3 {
-    flex-direction: column;
-  }
-
-  .footer-right {
-    padding-left: 0;
-  }
-
-  .footer-container .col-spacer {
-    margin-top: 40px;
   }
 
   .footer-bottom .our-nonprofit a {
@@ -2106,22 +2080,7 @@ p.footer-donation a:hover {
   }
 }
 
-@media (min-width: 1020px) {
-  .footer-container {
-    width: 850px;
-  }
-}
-
 @media (min-width: 1200px) {
-  .footer-container {
-    width: 1170px;
-  }
-
-  .footer-top {
-    display: flex;
-    flex-direction: row;
-  }
-
   .footer-desc-col {
     flex: 1 0 45%;
   }
@@ -2130,39 +2089,27 @@ p.footer-donation a:hover {
     flex: 1 0 58%;
   }
 
-  .footer-col-1 {
-    flex: 1 0 25%;
-  }
-
-  .footer-col-3 {
-    flex: 1 0 30%;
-  }
-
-  .footer-col-2 {
-    flex: 1 0 20%;
-  }
-
   p.footer-donation {
-    margin-top: 18px;
+    margin-top: 40px;
   }
 
   .footer-bottom .our-nonprofit {
-    padding: 0 10px;
+    padding-inline: 10px;
+    padding-top: 1.25rem;
     justify-content: space-between;
   }
 
   .footer-bottom .col-header {
-    display: none;
+    visibility: hidden;
+    padding: 0px;
+    margin: 0;
+    height: 1px;
   }
 
   .our-nonprofit {
-    margin-top: 20px;
-  }
-
-  .footer-divider {
-    height: 1px;
-    margin: 0 15px;
-    background-color: var(--gray15);
+    border-top: 1px;
+    border-top-style: solid;
+    border-top-color: var(--gray15);
   }
 }
 

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2058,6 +2058,23 @@ p.footer-donation a:hover {
   margin: 0 0 3rem;
 }
 
+.mobile-app-container {
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.mobile-app-container img {
+  width: 17.1rem;
+  height: 5.4rem;
+  object-fit: cover;
+}
+
 .footer-bottom .our-nonprofit {
   display: flex;
   flex-direction: row;
@@ -2072,6 +2089,10 @@ p.footer-donation a:hover {
 @media (min-width: 500px) {
   .footer-col {
     font-size: 15;
+  }
+
+  .mobile-app-container {
+    flex-direction: row;
   }
 }
 

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2128,7 +2128,7 @@ p.footer-donation a:hover {
   justify-content: center;
   padding-bottom: 2vw;
   padding-top: 2vw;
-  margin-bottom: 30px;
+  margin-bottom: 15px;
 }
 
 #readMoreBtn {

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2038,7 +2038,6 @@ pre.runkit-element {
   padding-inline: 15px;
   margin-bottom: 30px;
   align-self: start;
-  margin-top: 24px;
 }
 
 .footer-desc-col a {

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2123,6 +2123,7 @@ p.footer-donation a:hover {
   justify-content: center;
   padding-bottom: 2vw;
   padding-top: 2vw;
+  margin-bottom: 30px;
 }
 
 #readMoreBtn {

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2037,7 +2037,8 @@ pre.runkit-element {
 .footer-desc-col {
   padding-inline: 15px;
   margin-bottom: 30px;
-  align-self: center;
+  align-self: start;
+  margin-top: 24px;
 }
 
 .footer-desc-col a {

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2004,6 +2004,11 @@ pre.runkit-element {
   grid-row-gap: 0.5rem;
 }
 
+.trending-guides-articles li {
+  padding: 0;
+  margin: 0;
+}
+
 @media (max-width: 1400px) {
   .trending-guides-articles {
     grid-template-columns: repeat(auto-fit, minmax(12em, 1fr));

--- a/src/_includes/assets/js/pagination.js
+++ b/src/_includes/assets/js/pagination.js
@@ -1,5 +1,6 @@
 (async () => {
   const readMoreBtn = document.getElementById('readMoreBtn');
+  const readMoreRow = document.querySelector('.read-more-row');
   const postFeed = document.querySelector('.post-feed');
   let nextPageNum = 1;
 
@@ -20,7 +21,7 @@
         nextPageNum++;
         return parser.parseFromString(text, 'text/html');
       } else {
-        readMoreBtn.style.display = 'none';
+        readMoreRow.remove();
       }
     } catch (e) {
       console.error(`Connection error: ${e}`);

--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,197 +1,243 @@
 {% set donateUrl %}{% t "links:donate" %}{% endset %}
 
 <footer class="site-footer">
-    <div class="footer-container">
-        <div class="footer-top">
-            <div class="footer-desc-col">
-                <p data-test-label="tax-exempt-status">{% t 'footer.tax-exempt-status' %}</p>
-                <p data-test-label="mission-statement">{% t 'footer.mission-statement' %}</p>
-                <p data-test-label="donation-initiatives">{% t 'footer.donation-initiatives' %}</p>
-                <p class="footer-donation" data-test-label="donate-text">
-                    {% t 'footer.donate-text', {
-                        '<0>': '<a href="' + ( donateUrl ) + '" class="inline" rel="noopener noreferrer" target="_blank" >',
-                        '</0>': '</a>',
-                        interpolation: {
-                            escapeValue: false
-                        }
-                    } %}
-                </p>
-            </div>
-            <div class="trending-guides" data-test-label="trending-guides">
-                <div class="col-header">{% t 'footer.trending-guides' %}</div>
-                <div class="trending-guides-row">
-                    <div class="footer-col footer-col-1">
-                        <a href="{% t 'trending:article0link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article0title %}{% t 'trending:article0title' %}{% endset -%}
-                            {{ article0title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article1link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article1title %}{% t 'trending:article1title' %}{% endset -%}
-                            {{ article1title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article2link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article2title %}{% t 'trending:article2title' %}{% endset -%}
-                            {{ article2title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article3link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article3title %}{% t 'trending:article3title' %}{% endset -%}
-                            {{ article3title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article4link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article4title %}{% t 'trending:article4title' %}{% endset -%}
-                            {{ article4title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article5link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article5title %}{% t 'trending:article5title' %}{% endset -%}
-                            {{ article5title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article6link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article6title %}{% t 'trending:article6title' %}{% endset -%}
-                            {{ article6title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article7link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article7title %}{% t 'trending:article7title' %}{% endset -%}
-                            {{ article7title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article8link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article8title %}{% t 'trending:article8title' %}{% endset -%}
-                            {{ article8title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article9link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article9title %}{% t 'trending:article9title' %}{% endset -%}
-                            {{ article9title | escape }}
-                        </a>
-                    </div>
-                    <div class="footer-col footer-col-2">
-                        <a href="{% t 'trending:article10link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article10title %}{% t 'trending:article10title' %}{% endset -%}
-                            {{ article10title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article11link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article11title %}{% t 'trending:article11title' %}{% endset -%}
-                            {{ article11title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article12link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article12title %}{% t 'trending:article12title' %}{% endset -%}
-                            {{ article12title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article13link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article13title %}{% t 'trending:article13title' %}{% endset -%}
-                            {{ article13title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article14link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article14title %}{% t 'trending:article14title' %}{% endset -%}
-                            {{ article14title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article15link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article15title %}{% t 'trending:article15title' %}{% endset -%}
-                            {{ article15title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article16link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article16title %}{% t 'trending:article16title' %}{% endset -%}
-                            {{ article16title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article17link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article17title %}{% t 'trending:article17title' %}{% endset -%}
-                            {{ article17title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article18link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article18title %}{% t 'trending:article18title' %}{% endset -%}
-                            {{ article18title | escape }}
-                        </a>
-                        <a href="{% t 'trending:article19link' %}" rel="noopener noreferrer" target="_blank">
-                            {%- set article19title %}{% t 'trending:article19title' %}{% endset -%}
-                            {{ article19title | escape }}
-                        </a>
-                    </div>
-                    <div class="footer-col footer-col-3">
-                        <div class="footer-left">
-                            <a href="{% t 'trending:article20link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article20title %}{% t 'trending:article20title' %}{% endset -%}
-                                {{ article20title | escape }}
-                            </a>
-                            <a href="{% t 'trending:article21link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article21title %}{% t 'trending:article21title' %}{% endset -%}
-                                {{ article21title | escape }}
-                            </a>
-                            <a href="{% t 'trending:article22link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article22title %}{% t 'trending:article22title' %}{% endset -%}
-                                {{ article22title | escape }}
-                            </a>
-                            <a href="{% t 'trending:article23link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article23title %}{% t 'trending:article23title' %}{% endset -%}
-                                {{ article23title | escape }}
-                            </a>
-                            <a href="{% t 'trending:article24link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article24title %}{% t 'trending:article24title' %}{% endset -%}
-                                {{ article24title | escape }}
-                            </a>
-                        </div>
-
-                        <div class="footer-right">
-                            <a href="{% t 'trending:article25link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article25title %}{% t 'trending:article25title' %}{% endset -%}
-                                {{ article25title | escape }}
-                            </a>
-                            <a href="{% t 'trending:article26link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article26title %}{% t 'trending:article26title' %}{% endset -%}
-                                {{ article26title | escape }}
-                            </a>
-                            <a href="{% t 'trending:article27link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article27title %}{% t 'trending:article27title' %}{% endset -%}
-                                {{ article27title | escape }}
-                            </a>
-                            <a href="{% t 'trending:article28link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article28title %}{% t 'trending:article28title' %}{% endset -%}
-                                {{ article28title | escape }}
-                            </a>
-                            <a href="{% t 'trending:article29link' %}" rel="noopener noreferrer" target="_blank">
-                                {%- set article29title %}{% t 'trending:article29title' %}{% endset -%}
-                                {{ article29title | escape }}
-                            </a>
-                        </div>
-                    </div>
-                </div>
-            </div>
+    <div class="footer-top">
+        <div class="footer-desc-col">
+            <p data-test-label="tax-exempt-status">{% t 'footer.tax-exempt-status' %}</p>
+            <p data-test-label="mission-statement">{% t 'footer.mission-statement' %}</p>
+            <p data-test-label="donation-initiatives">{% t 'footer.donation-initiatives' %}</p>
+            <p class="footer-donation" data-test-label="donate-text">
+                {% t 'footer.donate-text', {
+                    '<0>': '<a href="' + ( donateUrl ) + '" class="inline" rel="noopener noreferrer" target="_blank" >',
+                    '</0>': '</a>',
+                    interpolation: {
+                        escapeValue: false
+                    }
+                } %}
+            </p>
         </div>
-        <div class='footer-bottom'>
-            <div class="col-header" data-test-label="our-nonprofit">{% t 'footer.our-nonprofit' %}</div>
-            <div class="footer-divider"></div>
-            <div class="our-nonprofit">
-                <a href="{% t 'links:footer.about' %}" rel="noopener noreferrer" target="_blank" data-test-label="about">
-                    {% t 'footer.links.about' %}
-                </a>
-                <a href="https://www.linkedin.com/school/free-code-camp/people/" rel="noopener noreferrer" target="_blank" data-test-label="alumni">
-                    {% t 'footer.links.alumni' %}
-                </a>
-                <a href="https://github.com/freeCodeCamp/" rel="noopener noreferrer" target="_blank" data-test-label="open-source">
-                    {% t 'footer.links.open-source' %}
-                </a>
-                <a href="https://www.freecodecamp.org/news/shop/" rel="noopener noreferrer" target="_blank" data-test-label="shop">
-                    {% t 'footer.links.shop' %}
-                </a>
-                <a href="{% t 'links:footer.support' %}" rel="noopener noreferrer" target="_blank" data-test-label="support">
-                    {% t 'footer.links.support' %}
-                </a>
-                <a href="https://www.freecodecamp.org/news/sponsors/" rel="noopener noreferrer" target="_blank" data-test-label="sponsors">
-                    {% t 'footer.links.sponsors' %}
-                </a>
-                <a href="{% t 'links:footer.honesty' %}" rel="noopener noreferrer" target="_blank" data-test-label="honesty">
-                    {% t 'footer.links.honesty' %}
-                </a>
-                <a href="{% t 'links:footer.coc' %}" rel="noopener noreferrer" target="_blank" data-test-label="coc">
-                    {% t 'footer.links.coc' %}
-                </a>
-                <a href="https://www.freecodecamp.org/news/privacy-policy/" rel="noopener noreferrer" target="_blank" data-test-label="privacy">
-                    {% t 'footer.links.privacy' %}
-                </a>
-                <a href="https://www.freecodecamp.org/news/terms-of-service/" rel="noopener noreferrer" target="_blank" data-test-label="tos">
-                    {% t 'footer.links.tos' %}
-                </a>
-                <a href="https://www.freecodecamp.org/news/copyright-policy/" rel="noopener noreferrer" target="_blank" data-test-label="copyright">
-                    {% t 'footer.links.copyright' %}
-                </a>
-            </div>
+        <div class="trending-guides" data-test-label="trending-guides">
+            <h2 id="trending-guides" class="col-header">{% t 'footer.trending-guides' %}</h2>
+            <ul class="trending-guides-articles" aria-labelledby="trending-guides">
+                <li>
+                    <a href="{% t 'trending:article0link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article0title %}{% t 'trending:article0title' %}{% endset -%}
+                        {{ article0title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article1link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article1title %}{% t 'trending:article1title' %}{% endset -%}
+                        {{ article1title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article2link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article2title %}{% t 'trending:article2title' %}{% endset -%}
+                        {{ article2title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article3link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article3title %}{% t 'trending:article3title' %}{% endset -%}
+                        {{ article3title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article4link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article4title %}{% t 'trending:article4title' %}{% endset -%}
+                        {{ article4title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article5link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article5title %}{% t 'trending:article5title' %}{% endset -%}
+                        {{ article5title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article6link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article6title %}{% t 'trending:article6title' %}{% endset -%}
+                        {{ article6title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article7link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article7title %}{% t 'trending:article7title' %}{% endset -%}
+                        {{ article7title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article8link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article8title %}{% t 'trending:article8title' %}{% endset -%}
+                        {{ article8title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article9link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article9title %}{% t 'trending:article9title' %}{% endset -%}
+                        {{ article9title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article10link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article10title %}{% t 'trending:article10title' %}{% endset -%}
+                        {{ article10title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article11link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article11title %}{% t 'trending:article11title' %}{% endset -%}
+                        {{ article11title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article12link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article12title %}{% t 'trending:article12title' %}{% endset -%}
+                        {{ article12title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article13link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article13title %}{% t 'trending:article13title' %}{% endset -%}
+                        {{ article13title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article14link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article14title %}{% t 'trending:article14title' %}{% endset -%}
+                        {{ article14title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article15link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article15title %}{% t 'trending:article15title' %}{% endset -%}
+                        {{ article15title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article16link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article16title %}{% t 'trending:article16title' %}{% endset -%}
+                        {{ article16title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article17link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article17title %}{% t 'trending:article17title' %}{% endset -%}
+                        {{ article17title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article18link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article18title %}{% t 'trending:article18title' %}{% endset -%}
+                        {{ article18title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article19link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article19title %}{% t 'trending:article19title' %}{% endset -%}
+                        {{ article19title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article20link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article20title %}{% t 'trending:article20title' %}{% endset -%}
+                        {{ article20title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article21link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article21title %}{% t 'trending:article21title' %}{% endset -%}
+                        {{ article21title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article22link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article22title %}{% t 'trending:article22title' %}{% endset -%}
+                        {{ article22title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article23link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article23title %}{% t 'trending:article23title' %}{% endset -%}
+                        {{ article23title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article24link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article24title %}{% t 'trending:article24title' %}{% endset -%}
+                        {{ article24title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article25link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article25title %}{% t 'trending:article25title' %}{% endset -%}
+                        {{ article25title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article26link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article26title %}{% t 'trending:article26title' %}{% endset -%}
+                        {{ article26title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article27link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article27title %}{% t 'trending:article27title' %}{% endset -%}
+                        {{ article27title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article28link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article28title %}{% t 'trending:article28title' %}{% endset -%}
+                        {{ article28title | escape }}
+                    </a>
+                </li>
+                <li>
+                    <a href="{% t 'trending:article29link' %}" rel="noopener noreferrer" target="_blank">
+                        {%- set article29title %}{% t 'trending:article29title' %}{% endset -%}
+                        {{ article29title | escape }}
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </div>
+    <div class='footer-bottom'>
+        <h2 class="col-header" data-test-label="our-nonprofit">{% t 'footer.our-nonprofit' %}</h2>
+        <div class="our-nonprofit">
+            <a href="{% t 'links:footer.about' %}" rel="noopener noreferrer" target="_blank" data-test-label="about">
+                {% t 'footer.links.about' %}
+            </a>
+            <a href="https://www.linkedin.com/school/free-code-camp/people/" rel="noopener noreferrer" target="_blank" data-test-label="alumni">
+                {% t 'footer.links.alumni' %}
+            </a>
+            <a href="https://github.com/freeCodeCamp/" rel="noopener noreferrer" target="_blank" data-test-label="open-source">
+                {% t 'footer.links.open-source' %}
+            </a>
+            <a href="https://www.freecodecamp.org/news/shop/" rel="noopener noreferrer" target="_blank" data-test-label="shop">
+                {% t 'footer.links.shop' %}
+            </a>
+            <a href="{% t 'links:footer.support' %}" rel="noopener noreferrer" target="_blank" data-test-label="support">
+                {% t 'footer.links.support' %}
+            </a>
+            <a href="https://www.freecodecamp.org/news/sponsors/" rel="noopener noreferrer" target="_blank" data-test-label="sponsors">
+                {% t 'footer.links.sponsors' %}
+            </a>
+            <a href="{% t 'links:footer.honesty' %}" rel="noopener noreferrer" target="_blank" data-test-label="honesty">
+                {% t 'footer.links.honesty' %}
+            </a>
+            <a href="{% t 'links:footer.coc' %}" rel="noopener noreferrer" target="_blank" data-test-label="coc">
+                {% t 'footer.links.coc' %}
+            </a>
+            <a href="https://www.freecodecamp.org/news/privacy-policy/" rel="noopener noreferrer" target="_blank" data-test-label="privacy">
+                {% t 'footer.links.privacy' %}
+            </a>
+            <a href="https://www.freecodecamp.org/news/terms-of-service/" rel="noopener noreferrer" target="_blank" data-test-label="tos">
+                {% t 'footer.links.tos' %}
+            </a>
+            <a href="https://www.freecodecamp.org/news/copyright-policy/" rel="noopener noreferrer" target="_blank" data-test-label="copyright">
+                {% t 'footer.links.copyright' %}
+            </a>
         </div>
     </div>
 </footer>

--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -1,4 +1,6 @@
 {% set donateUrl %}{% t "links:donate" %}{% endset %}
+{# {% from "assets/images/footer-ads/apple-store-badge.njk" import appleStoreBadge %}
+{% from "assets/images/footer-ads/google-play-badge.njk" import googlePlayBadge %} #}
 
 <footer class="site-footer">
     <div class="footer-top">
@@ -200,6 +202,34 @@
                     </a>
                 </li>
             </ul>
+            <div class="spacer" style="padding: 15px 0;"></div>
+            <div>
+                <h2 id="mobile-app" class="col-header">
+                    {% t "footer.mobile-app" %}
+                </h2>
+                <div class="min-h-[1px] px-[15px] md:w-2/3 md:ml-[16.6%]">
+                    <ul aria-labelledby="mobile-app" class="mobile-app-container">
+                        <li>
+                            <a href="https://apps.apple.com/us/app/freecodecamp/id6446908151?itsct=apps_box_link&itscg=30200" rel="noopener noreferrer" target="_blank">
+                                <img
+                                    src="https://cdn.freecodecamp.org/platform/universal/apple-store-badge.svg"
+                                    lang="en"
+                                    alt="Download on the App Store"
+                                />
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://play.google.com/store/apps/details?id=org.freecodecamp" rel="noopener noreferrer" target="_blank">
+                                <img
+                                    src="https://cdn.freecodecamp.org/platform/universal/google-play-badge.svg"
+                                    lang="en"
+                                    alt="Get it on Google Play"
+                                />
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
         </div>
     </div>
     <div class='footer-bottom'>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Partially addresses https://github.com/freeCodeCamp/freeCodeCamp/issues/52189

**Note:** https://github.com/freeCodeCamp/cdn/pull/244 should get merged first if we go with CDN served app badges.

<!-- Feel free to add any additional description of changes below this line -->
This PR brings in the bulk of the structural and styling updates from https://github.com/freeCodeCamp/freeCodeCamp/pull/52345 to the News footer.

There are also some minor changes to the way the "Load More Articles" button is removed from News pages that aren't populated by Algolia. There's a bit of a bottom margin to add some extra space between the button container and the footer. Also we'll remove the entire button container when there are no other article cards to load.

Desktop with the "Load More Articles" button:

![image](https://github.com/freeCodeCamp/news/assets/2051070/05abbe50-8089-4b5e-bcd1-341d75552690)

Mobile with the "Load More Articles" button:

![image](https://github.com/freeCodeCamp/news/assets/2051070/fd21bc8c-30f6-4bd5-b2d7-acb54584af9a)

Desktop without the "Load More Articles" button:

![image](https://github.com/freeCodeCamp/news/assets/2051070/59452e76-a4ba-4279-a077-36713ace6a40)

Mobile without the "Load More Articles" button:

![image](https://github.com/freeCodeCamp/news/assets/2051070/0e2506be-8de0-4c69-87c8-957bc3b9f8df)