### PR TITLE
chore: add editor config for Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,8 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
+
+[makefile]
+indent_style = tab
+[Makefile]
+indent_style = tab

--- a/registry-test/Makefile
+++ b/registry-test/Makefile
@@ -9,7 +9,7 @@ DOCKER_REPO := registry.digitalocean.com/${REGISTRY_NAME}/ops/test
 .PHONY: build
 build:
 	docker build \
-  --build-arg BUILD_ID=$(LOCAL_TAGNAME) \
+	--build-arg BUILD_ID=$(LOCAL_TAGNAME) \
 	--platform linux/amd64 \
 	--tag $(DOCKER_REPO):${LOCAL_TAGNAME} \
 	--tag $(DOCKER_REPO):latest \


### PR DESCRIPTION
Two entries because TOML is case-insensitive
