### PR TITLE
chore: remove ads.txt file from builds

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,9 +1,4 @@
-const {
-  readFileSync,
-  readdirSync,
-  writeFileSync,
-  unlinkSync
-} = require('graceful-fs');
+const { readFileSync, readdirSync, writeFileSync } = require('graceful-fs');
 const pluginRSS = require('@11ty/eleventy-plugin-rss');
 const UpgradeHelper = require('@11ty/eleventy-upgrade-help');
 
@@ -53,9 +48,6 @@ module.exports = function (config) {
 
       writeFileSync(fullPath, cssMin(content));
     });
-
-    // Remove ads.txt from Chinese build
-    if (currentLocale_i18n === 'chinese') unlinkSync('./dist/ads.txt');
 
     // Write translated locales for the current build language to the assets directory
     // as a workaround to display those strings in search-results.js instead of with the

--- a/src/ads-txt.njk
+++ b/src/ads-txt.njk
@@ -1,4 +1,0 @@
----
-permalink: 'ads.txt'
----
-google.com, {{ secrets.googleAdsenseDataAdClient | replace("ca-", "") }}, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Now that the `ads.txt` file is being picked up from the root freecodecamp.org directory / Learn, we can remove it here.