### PR TITLE
fix: add fallback feature image

### DIFF
--- a/cypress/e2e/english/landing/landing.cy.js
+++ b/cypress/e2e/english/landing/landing.cy.js
@@ -2,6 +2,7 @@ const commonExpectedMeta = require('../../../fixtures/common-expected-meta.json'
 const { loadAllPosts } = require('../../../support/utils/post-cards');
 
 const selectors = {
+  featureImage: "[data-test-label='feature-image']",
   postCard: "[data-test-label='post-card']",
   authorList: "[data-test-label='author-list']",
   authorProfileImage: "[data-test-label='profile-image']",
@@ -71,5 +72,11 @@ describe('Landing', () => {
       .parentsUntil('article')
       .find(selectors.authorList)
       .should('not.exist');
+  });
+
+  it('each post card should contain a feature image', () => {
+    const numberOfPosts = Cypress.$(selectors.postCard).length;
+
+    cy.get(selectors.featureImage).should('have.length', numberOfPosts);
   });
 });

--- a/cypress/e2e/english/page/page.cy.js
+++ b/cypress/e2e/english/page/page.cy.js
@@ -1,4 +1,5 @@
 const selectors = {
+  featureImage: "[data-test-label='feature-image']",
   postContent: "[data-test-label='post-content']"
 };
 
@@ -30,6 +31,26 @@ describe('Page', () => {
         .last()
         .should('have.prop', 'tagName', 'P')
         .should('not.have.attr', 'data-test-label', 'fitted');
+    });
+  });
+
+  context('Includes feature image', () => {
+    beforeEach(() => {
+      cy.visit('/thank-you-for-donating/');
+    });
+
+    it('pages with a feature image should include a feature image element', () => {
+      cy.get(selectors.featureImage).should('exist');
+    });
+  });
+
+  context('No feature image', () => {
+    beforeEach(() => {
+      cy.visit('/embedded-videos-page/');
+    });
+
+    it('pages with no feature image should **not** fall back to the default fCC indigo image', () => {
+      cy.get(selectors.featureImage).should('not.exist');
     });
   });
 });

--- a/cypress/e2e/english/post/post.cy.js
+++ b/cypress/e2e/english/post/post.cy.js
@@ -1,4 +1,5 @@
 const selectors = {
+  featureImage: "[data-test-label='feature-image']",
   authorProfileImage: "[data-test-label='profile-image']",
   ghostDefaultAvatar: "[data-test-label='avatar']",
   postContent: "[data-test-label='post-content']",
@@ -98,6 +99,22 @@ describe('Post', () => {
           .should('not.have.attr', 'data-test-label', 'fitted');
       });
     });
+
+    context('No feature image', () => {
+      beforeEach(() => {
+        cy.visit('/ghost-no-feature-image/');
+      });
+
+      it('posts with no feature image should fall back to the default fCC indigo image', () => {
+        cy.get(selectors.featureImage)
+          .should('exist')
+          .then($el =>
+            expect($el[0].src).to.equal(
+              'https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png'
+            )
+          );
+      });
+    });
   });
 
   context('Hashnode sourced posts', () => {
@@ -175,6 +192,22 @@ describe('Post', () => {
         cy.get(selectors.authorProfileImage).then($el =>
           expect($el[0].alt).to.equal('Dionysia Lemonaki')
         );
+      });
+    });
+
+    context('No feature image', () => {
+      beforeEach(() => {
+        cy.visit('/hashnode-no-feature-image/');
+      });
+
+      it('posts with no feature image should fall back to the default fCC indigo image', () => {
+        cy.get(selectors.featureImage)
+          .should('exist')
+          .then($el =>
+            expect($el[0].src).to.equal(
+              'https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png'
+            )
+          );
       });
     });
   });

--- a/cypress/fixtures/mock-hashnode-posts.json
+++ b/cypress/fixtures/mock-hashnode-posts.json
@@ -6,8 +6,8 @@
         {
           "node": {
             "id": "661e2bc550a7433c8ecc4d0b",
-            "slug": "hashnode-no-cover-image",
-            "title": "Hashnode No Cover Image",
+            "slug": "hashnode-no-feature-image",
+            "title": "Hashnode No Feature Image",
             "author": {
               "id": "5e135008490269cb3022acbf",
               "username": "scissorsneedfoodtoo",

--- a/cypress/fixtures/mock-hashnode-posts.json
+++ b/cypress/fixtures/mock-hashnode-posts.json
@@ -5,6 +5,43 @@
       "edges": [
         {
           "node": {
+            "id": "661e2bc550a7433c8ecc4d0b",
+            "slug": "hashnode-no-cover-image",
+            "title": "Hashnode No Cover Image",
+            "author": {
+              "id": "5e135008490269cb3022acbf",
+              "username": "scissorsneedfoodtoo",
+              "name": "Kristofer Koishigawa",
+              "bio": {
+                "text": ""
+              },
+              "profilePicture": "https://cdn.hashnode.com/res/hashnode/image/upload/v1710857138258/qSuNPwWGp.jpeg",
+              "socialMediaLinks": {
+                "website": "https://kriskoishigawa.com",
+                "twitter": "https://twitter.com/kriskoishigawa",
+                "facebook": ""
+              },
+              "location": ""
+            },
+            "tags": [
+              {
+                "id": "56744723958ef13879b9549b",
+                "name": "Testing",
+                "slug": "testing"
+              }
+            ],
+            "coverImage": null,
+            "brief": "Force dog to sleep on floor and litter kitter kitty litty little kitten big roar roar feed me, why use post when this sofa is here paw your face to wake you up in the morning claws in your leg.",
+            "readTimeInMinutes": 1,
+            "content": {
+              "html": "<p>Force dog to sleep on floor and litter kitter kitty litty little kitten big roar roar feed me, why use post when this sofa is here paw your face to wake you up in the morning claws in your leg.</p>\n"
+            },
+            "publishedAt": "2024-04-16T07:41:57.015Z",
+            "updatedAt": null
+          }
+        },
+        {
+          "node": {
             "id": "660aae505256f62ea103144a",
             "slug": "freecodecamp-press-books-handbooks",
             "title": "Introducing freeCodeCamp Press – Free Books for Developers",

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -15,7 +15,7 @@ time #}
 {% block content %}
     <main id="site-main" class="post-template site-main outer">
         <div class="inner {{ "ad-layout" if (adsEnabled) }}">
-            <article class="post-full post {{ "no-image" if not (post.feature_image) }}">
+            <article class="post-full post }}">
                 <header class="post-full-header">
                     <section class="post-full-meta">
                         <time class="post-full-meta-date" datetime="{{ post.published_at }}">
@@ -40,20 +40,18 @@ time #}
                         {% endif %}
                     {% endif %}
                 </div>
-                {% if post.feature_image %}
-                    <figure class="post-full-image">
-                        {%
-                            featureImage
-                            post.feature_image,
-                            (title | escape),
-                            "(max-width: 800px) 400px,
-                             (max-width: 1170px) 700px,
-                             1400px",
-                            [300, 600, 1000, 2000],
-                            post.image_dimensions.feature_image
-                        %}
-                    </figure>
-                {% endif %}
+                <figure class="post-full-image">
+                    {%
+                        featureImage
+                        post.feature_image,
+                        (title | escape),
+                        "(max-width: 800px) 400px,
+                            (max-width: 1170px) 700px,
+                            1400px",
+                        [300, 600, 1000, 2000],
+                        post.image_dimensions.feature_image
+                    %}
+                </figure>
                 <section class="post-full-content">
                     <div class="post-and-sidebar">
                         <section class="post-content {{ "medium-migrated-article" if (post.primary_author.name === "freeCodeCamp.org") }}" data-test-label="post-content">

--- a/src/_includes/partials/card.njk
+++ b/src/_includes/partials/card.njk
@@ -5,27 +5,23 @@
     {% set primaryTag = post.tags[0] %}
 
     <article class="post-card" data-test-label="post-card">
-        {% if post.feature_image %}
-            <a class="post-card-image-link" href="{{ post.path }}" aria-label="{{ post.title }}">
-                {%
-                    image
-                    post.feature_image,
-                    "post-card-image",
-                    (post.title | escape),
-                    "(max-width: 360px) 300px,
-                     (max-width: 655px) 600px,
-                     (max-width: 767px) 1000px,
-                     (min-width: 768px) 300px,
-                     92vw",
-                    [300, 600, 1000, 2000],
-                    post.image_dimensions.feature_image,
-                    "feature-image",
-                    lazyLoad
-                %}
-            </a>
-        {% else %}
-            <div class="no-feature-image-offsetter"></div>
-        {% endif %}
+        <a class="post-card-image-link" href="{{ post.path }}" aria-label="{{ post.title }}">
+            {%
+                image
+                post.feature_image,
+                "post-card-image",
+                (post.title | escape),
+                "(max-width: 360px) 300px,
+                    (max-width: 655px) 600px,
+                    (max-width: 767px) 1000px,
+                    (min-width: 768px) 300px,
+                    92vw",
+                [300, 600, 1000, 2000],
+                post.image_dimensions.feature_image,
+                "feature-image",
+                lazyLoad
+            %}
+        </a>
         <div class="post-card-content">
             <div class="post-card-content-link">
                 <header class="post-card-header">

--- a/utils/ghost/process-batch.js
+++ b/utils/ghost/process-batch.js
@@ -50,14 +50,17 @@ const processBatch = async ({ batch, type, currBatchNo, totalBatches }) => {
       obj.primary_author = removeUnusedKeys(obj.primary_author);
       obj.tags.map(tag => removeUnusedKeys(tag));
 
+      // Set a default feature image if one doesn't exist
+      if (!obj.feature_image)
+        obj.feature_image =
+          'https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png';
+
       // Feature image resolutions for structured data
-      if (obj.feature_image) {
-        obj.image_dimensions = { ...obj.image_dimensions };
-        obj.image_dimensions.feature_image = await getImageDimensions(
-          obj.feature_image,
-          obj.title
-        );
-      }
+      obj.image_dimensions = { ...obj.image_dimensions };
+      obj.image_dimensions.feature_image = await getImageDimensions(
+        obj.feature_image,
+        obj.title
+      );
 
       // Author image resolutions for structured data
       if (obj.primary_author.profile_image) {

--- a/utils/ghost/process-batch.js
+++ b/utils/ghost/process-batch.js
@@ -50,17 +50,19 @@ const processBatch = async ({ batch, type, currBatchNo, totalBatches }) => {
       obj.primary_author = removeUnusedKeys(obj.primary_author);
       obj.tags.map(tag => removeUnusedKeys(tag));
 
-      // Set a default feature image if one doesn't exist
-      if (!obj.feature_image)
+      // Set a default feature image for posts if one doesn't exist
+      if (type === 'posts' && !obj.feature_image)
         obj.feature_image =
           'https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png';
 
-      // Feature image resolutions for structured data
-      obj.image_dimensions = { ...obj.image_dimensions };
-      obj.image_dimensions.feature_image = await getImageDimensions(
-        obj.feature_image,
-        obj.title
-      );
+      if (obj.feature_image) {
+        // Feature image resolutions for structured data
+        obj.image_dimensions = { ...obj.image_dimensions };
+        obj.image_dimensions.feature_image = await getImageDimensions(
+          obj.feature_image,
+          obj.title
+        );
+      }
 
       // Author image resolutions for structured data
       if (obj.primary_author.profile_image) {

--- a/utils/hashnode/process-batch.js
+++ b/utils/hashnode/process-batch.js
@@ -16,6 +16,10 @@ const processBatch = async ({ batch, currBatchNo, totalBatches }) => {
     newPost.title = oldPost.title;
     newPost.reading_time = oldPost.readTimeInMinutes;
 
+    // Set a default feature image for posts if one doesn't exist
+    // Note: We're not handling pages from Hashnode, so there's no
+    // need to handle cases where we may not want to have a cover image
+    // for a particular page.
     newPost.feature_image = oldPost?.coverImage?.url
       ? oldPost.coverImage.url
       : 'https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png';

--- a/utils/hashnode/process-batch.js
+++ b/utils/hashnode/process-batch.js
@@ -16,14 +16,15 @@ const processBatch = async ({ batch, currBatchNo, totalBatches }) => {
     newPost.title = oldPost.title;
     newPost.reading_time = oldPost.readTimeInMinutes;
 
-    if (oldPost.coverImage) {
-      newPost.feature_image = oldPost.coverImage.url;
-      newPost.image_dimensions = {};
-      newPost.image_dimensions.feature_image = await getImageDimensions(
-        newPost.feature_image,
-        newPost.title
-      );
-    }
+    newPost.feature_image = oldPost?.coverImage?.url
+      ? oldPost.coverImage.url
+      : 'https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png';
+
+    newPost.image_dimensions = {};
+    newPost.image_dimensions.feature_image = await getImageDimensions(
+      newPost.feature_image,
+      newPost.title
+    );
 
     const newPostAuthor = {};
     newPostAuthor.id = oldPost.author.id;

--- a/utils/shortcodes/images.js
+++ b/utils/shortcodes/images.js
@@ -41,7 +41,7 @@ function imageShortcode(
 }
 
 // Copy images over from Ghost
-function featureImageShortcode(src, alt, sizes, widths, dimensions, testLabel) {
+function featureImageShortcode(src, alt, sizes, widths, dimensions) {
   const imageUrls = src.match(ghostImageRe)
     ? widths.map(width =>
         src.replace('/content/images/', `/content/images/size/w${width}/`)
@@ -70,7 +70,7 @@ function featureImageShortcode(src, alt, sizes, widths, dimensions, testLabel) {
         alt="${alt}",
         width="${dimensions.width}"
         height="${dimensions.height}"
-        data-test-label="${testLabel}"
+        data-test-label="feature-image"
       >
     </picture>
   `;

--- a/utils/shortcodes/images.js
+++ b/utils/shortcodes/images.js
@@ -41,7 +41,7 @@ function imageShortcode(
 }
 
 // Copy images over from Ghost
-function featureImageShortcode(src, alt, sizes, widths, dimensions) {
+function featureImageShortcode(src, alt, sizes, widths, dimensions, testLabel) {
   const imageUrls = src.match(ghostImageRe)
     ? widths.map(width =>
         src.replace('/content/images/', `/content/images/size/w${width}/`)
@@ -70,6 +70,7 @@ function featureImageShortcode(src, alt, sizes, widths, dimensions) {
         alt="${alt}",
         width="${dimensions.width}"
         height="${dimensions.height}"
+        data-test-label="${testLabel}"
       >
     </picture>
   `;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR adds support to use the following image as a fallback for posts from Ghost and Hashnode that don't have a feature / cover image: https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png

However, pages (currently only from Ghost) that do not include a feature image will continue not to fallback to anything, and won't include a feature image element. Pages are a bit special in that they never include an author, and there may be cases where we would want to publish a page with no cover image, and to only include text.

If we decide in the future to use a default image for all pages as well, we can simplify things a bit more.

Here are some screenshots:

- Landing page:

![image](https://github.com/freeCodeCamp/news/assets/2051070/c310f2a4-ad61-4d1c-bcdd-d798ac4ebe65)

- Ghost post with no feature image:

![image](https://github.com/freeCodeCamp/news/assets/2051070/c9153a3c-0fba-408a-9549-2c7568f4f230)

- Hashnode post with no feature image:

![image](https://github.com/freeCodeCamp/news/assets/2051070/627af3e3-8466-4955-a1ca-2500cf057e0b)