### PR TITLE
fix: replace gam canonocalUrl

### DIFF
--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -115,16 +115,8 @@
 
         {{ site.codeinjection_head | safe if site.codeinjection_head }}
         {{ codeinjection_head | safe if codeinjection_head }}
-        {% if canonicalUrl == "http://localhost:8080/news/embedded-videos-post/" %}
+        {% if canonicalUrl == "https://www.freecodecamp.org/news/are-you-being-micro-managed-manage-your-relationship-with-your-manager-instead-9ad10b28bcda/" %}
             <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
-            <script>
-            window.googletag = window.googletag || {cmd: []};
-            googletag.cmd.push(function() {
-                googletag.defineSlot('/23075930536/homepage-top-test', [[300, 1050], [300, 600]], 'div-gpt-ad-1711446808518-0').addService(googletag.pubads());
-                googletag.pubads().enableSingleRequest();
-                googletag.enableServices();
-            });
-            </script>
         {% endif %}
     </head>
 

--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -115,7 +115,7 @@
 
         {{ site.codeinjection_head | safe if site.codeinjection_head }}
         {{ codeinjection_head | safe if codeinjection_head }}
-        {% if canonicalUrl == "https://www.freecodecamp.org/news/are-you-being-micro-managed-manage-your-relationship-with-your-manager-instead-9ad10b28bcda/" %}
+        {% if canonicalUrl == "http://localhost:8080/news/embedded-videos-post/" %}
             <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
             <script>
             window.googletag = window.googletag || {cmd: []};

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -61,8 +61,10 @@ time #}
                         </section>
                         {% if adsEnabled %}
                             <div class="sidebar">
-                                {% if canonicalUrl == "http://localhost:8080/news/embedded-videos-post/" %}
-                                    {% include "partials/gam-ad.njk" %}
+                                {% if canonicalUrl == "https://www.freecodecamp.org/news/are-you-being-micro-managed-manage-your-relationship-with-your-manager-instead-9ad10b28bcda/" %}
+                                    {% for i in range(0, numOfSidebarAds) %}
+                                        {% include "partials/gam-ad.njk" %}
+                                      {% endfor %}
                                 {% else %}
                                     {% for i in range(0, numOfSidebarAds) %}
                                         {% include "partials/ad.njk" %}
@@ -92,7 +94,7 @@ time #}
                         {% include "partials/learn-cta-row.njk" %}
                     {% endif %}
                 </section>
-                {% if adsEnabled and canonicalUrl != "http://localhost:8080/news/embedded-videos-post/" %}
+                {% if adsEnabled and canonicalUrl != "https://www.freecodecamp.org/news/are-you-being-micro-managed-manage-your-relationship-with-your-manager-instead-9ad10b28bcda/" %}
                     <div class="banner-ad bottom">
                         {% include "partials/ad.njk" %}
                     </div>
@@ -107,13 +109,17 @@ time #}
 {% endblock %}
 
 {% block monetization %}
-    {% if adsEnabled and canonicalUrl != "http://localhost:8080/news/embedded-videos-post/" %}
-        <script
-            data-ad-client="{{ secrets.googleAdsenseDataAdClient }}"
-            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
-            crossorigin="anonymous"
-            async
-        ></script>
+    {% if adsEnabled %}
+        {% if canonicalUrl == "https://www.freecodecamp.org/news/are-you-being-micro-managed-manage-your-relationship-with-your-manager-instead-9ad10b28bcda/" %}
+            {% include "partials/gam-lazy-loader.njk" %}
+        {% else %}
+            <script
+                data-ad-client="{{ secrets.googleAdsenseDataAdClient }}"
+                src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"
+                crossorigin="anonymous"
+                async
+            ></script>
+        {% endif %}
     {% endif %}
 {% endblock %}
 

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -61,7 +61,7 @@ time #}
                         </section>
                         {% if adsEnabled %}
                             <div class="sidebar">
-                                {% if canonicalUrl == "https://www.freecodecamp.org/news/are-you-being-micro-managed-manage-your-relationship-with-your-manager-instead-9ad10b28bcda/" %}
+                                {% if canonicalUrl == "http://localhost:8080/news/embedded-videos-post/" %}
                                     {% include "partials/gam-ad.njk" %}
                                 {% else %}
                                     {% for i in range(0, numOfSidebarAds) %}
@@ -92,7 +92,7 @@ time #}
                         {% include "partials/learn-cta-row.njk" %}
                     {% endif %}
                 </section>
-                {% if adsEnabled and canonicalUrl != "https://www.freecodecamp.org/news/are-you-being-micro-managed-manage-your-relationship-with-your-manager-instead-9ad10b28bcda/" %}
+                {% if adsEnabled and canonicalUrl != "http://localhost:8080/news/embedded-videos-post/" %}
                     <div class="banner-ad bottom">
                         {% include "partials/ad.njk" %}
                     </div>
@@ -107,7 +107,7 @@ time #}
 {% endblock %}
 
 {% block monetization %}
-    {% if adsEnabled and canonicalUrl != "https://www.freecodecamp.org/news/are-you-being-micro-managed-manage-your-relationship-with-your-manager-instead-9ad10b28bcda/" %}
+    {% if adsEnabled and canonicalUrl != "http://localhost:8080/news/embedded-videos-post/" %}
         <script
             data-ad-client="{{ secrets.googleAdsenseDataAdClient }}"
             src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"

--- a/src/_includes/partials/gam-ad.njk
+++ b/src/_includes/partials/gam-ad.njk
@@ -2,9 +2,6 @@
     {% set localizedAdText %}{% t 'ad-text' %}{% endset %}
     <div class="ad-text" data-test-label="ad-text">{{ localizedAdText | upper }}</div>
     <!-- /23075930536/homepage-top-test -->
-    <div id='div-gpt-ad-1711446808518-0' style='min-width: 300px; min-height: 600px; background-color: #ebebeb;'>
-    <script>
-        googletag.cmd.push(function() { googletag.display('div-gpt-ad-1711446808518-0'); });
-    </script>
+    <div style='min-width: 300px; min-height: 600px; background-color: #ebebeb;' class="side-bar-ad-slot">
     </div>
 </div>

--- a/src/_includes/partials/gam-lazy-loader.njk
+++ b/src/_includes/partials/gam-lazy-loader.njk
@@ -1,0 +1,39 @@
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var adElements = document.querySelectorAll('.side-bar-ad-slot');
+        let counter = 0;
+        adElements.forEach(function(adElement) {
+            adElement.id = 'side-gam-ad-' + counter;
+            counter++;  // Increment the counter for the next ad element
+        });
+
+        // Define the distance from viewport as a variable
+        var loadBeforeViewport = 200; // Distance in pixels before the ad enters the viewport
+
+        window.googletag = window.googletag || {cmd: []};
+        googletag.cmd.push(function() {
+            adElements.forEach(function(adElement) {
+                googletag.defineSlot('/23075930536/homepage-top-test', [300, 600], adElement.id)
+                         .addService(googletag.pubads());
+
+                let observer = new IntersectionObserver((entries) => {
+                    entries.forEach((entry) => {
+                        if (entry.isIntersecting || entry.boundingClientRect.top <= loadBeforeViewport) {
+                            googletag.display(entry.target.id);
+                            observer.unobserve(entry.target); // Stop observing once the ad is loaded
+                        }
+                    });
+                }, {
+                    root: null, // Observe relative to the viewport
+                    rootMargin: '-' + loadBeforeViewport + 'px 0px 0px 0px', // Adjust rootMargin to use the variable
+                    threshold: 0.01
+                });
+
+                observer.observe(adElement); // Start observing each ad element
+            });
+
+            googletag.pubads().enableSingleRequest();
+            googletag.enableServices();
+        });
+    });
+</script>


### PR DESCRIPTION
this pr will add lazy loading to sidebar ads. 
Currently it does not load the ad 200 before the ad slot enters the page as intended and the logic could be optimized a bit further, but it could go in for testing.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
