### PR TITLE
feat: add datasource info to head

### DIFF
--- a/cypress/e2e/english/page/page.cy.js
+++ b/cypress/e2e/english/page/page.cy.js
@@ -1,4 +1,5 @@
 const selectors = {
+  fccSource: "[data-test-label='x-fcc-source']",
   featureImage: "[data-test-label='feature-image']",
   postContent: "[data-test-label='post-content']"
 };
@@ -13,6 +14,10 @@ describe('Page', () => {
       cy.contains(
         'Please check your email for a donation receipt. Forward it to donors@freecodecamp.org.'
       );
+    });
+
+    it('should contain the fCC source meta tag with Ghost as a source', () => {
+      cy.get(selectors.fccSource).should('have.attr', 'content', 'Ghost');
     });
   });
 

--- a/cypress/e2e/english/post/post.cy.js
+++ b/cypress/e2e/english/post/post.cy.js
@@ -1,4 +1,5 @@
 const selectors = {
+  fccSource: "[data-test-label='x-fcc-source']",
   featureImage: "[data-test-label='feature-image']",
   authorProfileImage: "[data-test-label='profile-image']",
   ghostDefaultAvatar: "[data-test-label='avatar']",
@@ -18,6 +19,10 @@ describe('Post', () => {
         cy.contains(
           "We're Building New Courses on Rust and Python + the Replit.web Framework"
         );
+      });
+
+      it('should contain the fCC source meta tag with Ghost as a source', () => {
+        cy.get(selectors.fccSource).should('have.attr', 'content', 'Ghost');
       });
     });
 
@@ -127,6 +132,10 @@ describe('Post', () => {
         cy.contains(
           'Introducing freeCodeCamp Press – Free Books for Developers'
         );
+      });
+
+      it('should contain the fCC source meta tag with Hashnode as a source', () => {
+        cy.get(selectors.fccSource).should('have.attr', 'content', 'Hashnode');
       });
     });
 

--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -118,6 +118,9 @@
         {% if canonicalUrl == "https://www.freecodecamp.org/news/are-you-being-micro-managed-manage-your-relationship-with-your-manager-instead-9ad10b28bcda/" %}
             <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
         {% endif %}
+
+        {% block datasourceInfo %}
+        {% endblock %}
     </head>
 
     {% if site.lang in ['ar', 'fa', 'ur', 'he'] %}

--- a/src/_includes/layouts/doc.njk
+++ b/src/_includes/layouts/doc.njk
@@ -99,3 +99,8 @@
 {% block jsonLd %}
     <script type="application/ld+json">{% createJSONLD 'article', site, doc %}</script>
 {% endblock %}
+
+{# Note: We can remove this once we source all pages from a single CMS #}
+{% block datasourceInfo %}
+  <meta name="x-fcc-source" data-test-label="x-fcc-source" content="{{ doc.source }}">
+{% endblock %}

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -167,3 +167,8 @@ time #}
 {% block jsonLd %}
     <script type="application/ld+json">{% createJSONLD 'article', site, post %}</script>
 {% endblock %}
+
+{# Note: We can remove this once we source all posts from a single CMS #}
+{% block datasourceInfo %}
+  <meta name="x-fcc-source" data-test-label="x-fcc-source" content="{{ post.source }}">
+{% endblock %}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR adds some hidden meta info to the `head` for posts and pages to show either Ghost or Hashnode as a datasource. This should help us with debugging while we move to Hashnode.

Here's an example of the meta tag that gets added dynamically:

- For Ghost sourced posts / pages: `<meta name="x-fcc-source" data-test-label="x-fcc-source" content="Ghost">`
- For Hashnode sourced posts / pages: `<meta name="x-fcc-source" data-test-label="x-fcc-source" content="Hashnode">`

And here are some screenshots for review:

![image](https://github.com/freeCodeCamp/news/assets/2051070/cb151e96-867a-47c5-b07e-5f5ca47c3bec)

![image](https://github.com/freeCodeCamp/news/assets/2051070/4424e114-71e3-456d-a743-929f138fa48e)

