### PR TITLE
fix: associate posts with authors by slug

### DIFF
--- a/cypress/e2e/english/author/author.cy.js
+++ b/cypress/e2e/english/author/author.cy.js
@@ -29,6 +29,20 @@ describe('Author page', () => {
       cy.viewport(499, 660);
       cy.get(selectors.bullet).should('not.be.visible');
     });
+
+    // Note: Quincy's username / slug on Hashnode is actually `quincy`, but has been changed in the test
+    // data to `quincylarson` to match his Ghost username / slug. This test can be removed once we migrate
+    // everything to Hashnode.
+    it('pages for authors with the same slug / username on both Ghost and Hashnode should show all posts', () => {
+      // Hashnode sourced post
+      cy.contains(
+        'Ben Awad is a GameDev Who Sleeps 9 Hours EVERY NIGHT to be Productive [Podcast #121]'
+      );
+      // Ghost sourced post
+      cy.contains(
+        'freeCodeCamp Just Got a Million Dollar Donation from an Alum to Build a Carbon-Neutral Web3 Curriculum'
+      );
+    });
   });
 
   context('Ghost sourced authors', () => {

--- a/cypress/e2e/english/tag/tag.cy.js
+++ b/cypress/e2e/english/tag/tag.cy.js
@@ -8,6 +8,23 @@ const selectors = {
 };
 
 describe('Tag pages', () => {
+  context('General tests', () => {
+    // Tests here should apply to all tag pages, regardless of the source
+    beforeEach(() => {
+      cy.visit('/tag/gamedev/');
+    });
+
+    // Note: This test can be removed once we migrate everything to Hashnode.
+    it('pages for tags with the same slug on both Ghost and Hashnode should show all posts', () => {
+      // Hashnode sourced post
+      cy.contains(
+        'Ben Awad is a GameDev Who Sleeps 9 Hours EVERY NIGHT to be Productive [Podcast #121]'
+      );
+      // Ghost sourced post
+      cy.contains('Learn to Code RPG – Full Soundtrack + How I Made It');
+    });
+  });
+
   context('Ghost sourced tags', () => {
     beforeEach(() => {
       cy.visit('/tag/javascript/');

--- a/cypress/fixtures/mock-hashnode-posts.json
+++ b/cypress/fixtures/mock-hashnode-posts.json
@@ -5,6 +5,51 @@
       "edges": [
         {
           "node": {
+            "id": "662bc86c57b91227386cc393",
+            "slug": "ben-awad-is-a-gamedev-who-sleeps-9-hours-every-night-to-be-productive-podcast-121",
+            "title": "Ben Awad is a GameDev Who Sleeps 9 Hours EVERY NIGHT to be Productive [Podcast #121]",
+            "author": {
+              "id": "5dfa3725066598ab2752cc5d",
+              "username": "quincylarson",
+              "name": "Quincy Larson",
+              "bio": {
+                "text": ""
+              },
+              "profilePicture": "https://cdn.hashnode.com/res/hashnode/image/upload/v1640878938509/PLqvxeH9g.jpeg",
+              "socialMediaLinks": {
+                "website": "https://www.freecodecamp.org",
+                "twitter": "https://www.twitter.com/ossia",
+                "facebook": ""
+              },
+              "location": ""
+            },
+            "tags": [
+              {
+                "id": "5ef8f394f32a5119fc5d3ae3",
+                "name": "GameDev",
+                "slug": "gamedev"
+              },
+              {
+                "id": "56744721958ef13879b94a60",
+                "name": "Productivity",
+                "slug": "productivity"
+              }
+            ],
+            "coverImage": {
+              "url": "https://cdn.hashnode.com/res/hashnode/image/upload/v1714145342153/09d7ca1e-feb2-4aac-8a68-b28060ee646c.jpeg"
+            },
+            "brief": "On this week's episode of the podcast, freeCodeCamp founder Quincy Larson interviews Ben Awad, a game developer who creates developer tutorials on YouTube and TikTok.\nI hope you enjoy our conversation.\nCan you guess what bass line I'm playing on my b...",
+            "readTimeInMinutes": 1,
+            "content": {
+              "html": "<p>On this week's episode of the podcast, freeCodeCamp founder Quincy Larson interviews Ben Awad, a game developer who creates developer tutorials on YouTube and TikTok.</p>\n<p>I hope you enjoy our conversation.</p>\n<p>Can you guess what bass line I'm playing on my bass during the intro? It's from a 1979 song.</p>\n<p>You can watch the interview on freeCodeCamp's YouTube channel:</p>\n<p>Or you can listen to the podcast in Apple Podcasts, Spotify, or your favorite podcast app. You can also listen to the podcast below, right in your browser:</p>\n<p>Be sure to follow The freeCodeCamp podcast in your favorite podcast app. And share this podcast with a friend. Let's inspire more folks to learn to code and build careers for themselves in tech.</p>\n<p>Also, I want to thank the 8,983 kind people who support our charity each month, and who make this podcast possible. You can join them and support our mission at: <a target=\"_blank\" href=\"https://www.freecodecamp.org/donate\">https://www.freecodecamp.org/donate</a></p>\n<h2 id=\"heading-links-we-talk-about-during-the-interview\">Links we talk about during the interview:</h2>\n<p>Ben's game, Void Pet on Android and iOS (Built in React Native): <a target=\"_blank\" href=\"https://voidpet.com/\">https://voidpet.com/</a></p>\n<p>XKCD coming on \"Real Programmers\" that Quincy mentions: <a target=\"_blank\" href=\"https://xkcd.com/378/\">https://xkcd.com/378/</a></p>\n<p>React Native course by Ben Awad: <a target=\"_blank\" href=\"https://www.freecodecamp.org/news/create-an-app-that-works-on-ios-android-and-the-web-with-react-native-web/\">https://www.freecodecamp.org/news/create-an-app-that-works-on-ios-android-and-the-web-with-react-native-web/</a></p>\n<p>I couldn't find my Mac Control hotkeys video tutorial that I mentioned anywhere, so I wrote a quick article explaining how to use these: <a target=\"_blank\" href=\"https://www.freecodecamp.org/news//mac-control-keyboard-shortcuts-hotkeys-macos\">https://www.freecodecamp.org/news//mac-control-keyboard-shortcuts-hotkeys-macos</a></p>\n",
+              "markdown": "On this week's episode of the podcast, freeCodeCamp founder Quincy Larson interviews Ben Awad, a game developer who creates developer tutorials on YouTube and TikTok.\n\nI hope you enjoy our conversation.\n\nCan you guess what bass line I'm playing on my bass during the intro? It's from a 1979 song.\n\nYou can watch the interview on freeCodeCamp's YouTube channel:\n\nOr you can listen to the podcast in Apple Podcasts, Spotify, or your favorite podcast app. You can also listen to the podcast below, right in your browser:\n\nBe sure to follow The freeCodeCamp podcast in your favorite podcast app. And share this podcast with a friend. Let's inspire more folks to learn to code and build careers for themselves in tech.\n\nAlso, I want to thank the 8,983 kind people who support our charity each month, and who make this podcast possible. You can join them and support our mission at: [https://www.freecodecamp.org/donate](https://www.freecodecamp.org/donate)\n\n## Links we talk about during the interview:\n\nBen's game, Void Pet on Android and iOS (Built in React Native): [https://voidpet.com/](https://voidpet.com/)\n\nXKCD coming on \"Real Programmers\" that Quincy mentions: [https://xkcd.com/378/](https://xkcd.com/378/)\n\nReact Native course by Ben Awad: [https://www.freecodecamp.org/news/create-an-app-that-works-on-ios-android-and-the-web-with-react-native-web/](https://www.freecodecamp.org/news/create-an-app-that-works-on-ios-android-and-the-web-with-react-native-web/)\n\nI couldn't find my Mac Control hotkeys video tutorial that I mentioned anywhere, so I wrote a quick article explaining how to use these: [https://www.freecodecamp.org/news//mac-control-keyboard-shortcuts-hotkeys-macos](https://www.freecodecamp.org/news//mac-control-keyboard-shortcuts-hotkeys-macos)"
+            },
+            "publishedAt": "2024-04-26T15:29:48.337Z",
+            "updatedAt": "2024-04-26T19:26:49.174Z"
+          }
+        },
+        {
+          "node": {
             "id": "661e2bc550a7433c8ecc4d0b",
             "slug": "hashnode-no-feature-image",
             "title": "Hashnode No Feature Image",

--- a/src/_data/datasource.js
+++ b/src/_data/datasource.js
@@ -97,7 +97,7 @@ module.exports = async () => {
   primaryAuthors.forEach(author => {
     // Attach posts to their respective author
     const currAuthorPosts = posts
-      .filter(post => post.primary_author.id === author.id)
+      .filter(post => post.primary_author.slug === author.slug)
       .map(post => {
         return {
           title: post.title,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Currently there's an issue where, if an author has the same username / slug on both Ghost and Hashnode, posts from whatever the second platform they wrote on (likely Hashnode) don't show up on their author pages.

For example, Estefania's latest post, [Build a Responsive Website with HTML and CSS - Course in Spanish](https://www.freecodecamp.org/news/build-a-responsive-website-with-html-and-css-full-course-in-spanish/), which was written on Hashnode, shows up on the News landing page, but not on her author page here: https://www.freecodecamp.org/news/author/estefaniacn/

This PR fixes this by associating posts with authors based on the author's slug rather than id, which likely comes from Ghost. Note that, while the test data here adds a recent post Quincy wrote on Hashnode, his slug has been changed from `quincy` to `quincylarson` to match what we have on Ghost.

This PR also adds in a test for tag pages, even though posts were already associated to tag pages by slug rather than id.