### PR TITLE
feat: use node-cache during build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "lint-staged": "15.2.7",
         "lodash": "4.17.21",
         "md5": "2.3.0",
+        "node-cache": "5.1.2",
         "node-fetch": "2.7.0",
         "npm-run-all2": "6.2.2",
         "piscina": "4.6.1",
@@ -9454,6 +9455,27 @@
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dev": true,
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-cache/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -19353,6 +19375,23 @@
       "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
       "dev": true,
       "optional": true
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dev": true,
+      "requires": {
+        "clone": "2.x"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+          "dev": true
+        }
+      }
     },
     "node-fetch": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "lint-staged": "15.2.7",
     "lodash": "4.17.21",
     "md5": "2.3.0",
+    "node-cache": "5.1.2",
     "node-fetch": "2.7.0",
     "npm-run-all2": "6.2.2",
     "piscina": "4.6.1",

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -41,8 +41,14 @@ module.exports = async () => {
   site.icon = iconUrl;
 
   // Determine image dimensions before server runs for structured data
-  const logoDimensions = await getImageDimensions(logoUrl);
-  const coverImageDimensions = await getImageDimensions(coverImageUrl);
+  const logoDimensions = await getImageDimensions(
+    logoUrl,
+    `Site logo: ${logoUrl}`
+  );
+  const coverImageDimensions = await getImageDimensions(
+    coverImageUrl,
+    `Site cover image: ${coverImageUrl}`
+  );
 
   site.image_dimensions = {
     logo: {

--- a/utils/cache.js
+++ b/utils/cache.js
@@ -1,0 +1,12 @@
+const NodeCache = require('node-cache');
+
+const cache = new NodeCache();
+
+const getCache = key => cache.get(key);
+
+const setCache = (key, data) => cache.set(key, data);
+
+module.exports = {
+  getCache,
+  setCache
+};

--- a/utils/ghost/original-post-handler.js
+++ b/utils/ghost/original-post-handler.js
@@ -42,7 +42,10 @@ const originalPostHandler = async post => {
           ...originalPost.primary_author.image_dimensions
         };
         originalPost.primary_author.image_dimensions.profile_image =
-          await getImageDimensions(originalPost.primary_author.profile_image);
+          await getImageDimensions(
+            originalPost.primary_author.profile_image,
+            `Original author profile image: ${originalPost.primary_author.profile_image}`
+          );
       }
 
       // Add an `original_post` object to the current post

--- a/utils/ghost/process-batch.js
+++ b/utils/ghost/process-batch.js
@@ -70,7 +70,7 @@ const processBatch = async ({
         obj.image_dimensions = { ...obj.image_dimensions };
         obj.image_dimensions.feature_image = await getImageDimensions(
           obj.feature_image,
-          obj.title
+          `Ghost post feature image: ${obj.title}`
         );
       }
 
@@ -82,8 +82,7 @@ const processBatch = async ({
         obj.primary_author.image_dimensions.profile_image =
           await getImageDimensions(
             obj.primary_author.profile_image,
-            obj.primary_author.name,
-            true
+            `Ghost author profile image: ${obj.primary_author.name}`
           );
       }
 
@@ -94,8 +93,7 @@ const processBatch = async ({
         obj.primary_author.image_dimensions.cover_image =
           await getImageDimensions(
             obj.primary_author.cover_image,
-            obj.primary_author.name,
-            true
+            `Ghost author cover image: ${obj.primary_author.name}`
           );
       }
 
@@ -106,8 +104,7 @@ const processBatch = async ({
             tag.image_dimensions = { ...tag.image_dimensions };
             tag.image_dimensions.feature_image = await getImageDimensions(
               tag.feature_image,
-              tag.name,
-              true
+              `Ghost tag feature image: ${tag.name}`
             );
           }
         })

--- a/utils/ghost/process-batch.js
+++ b/utils/ghost/process-batch.js
@@ -58,7 +58,8 @@ const processBatch = async ({
 
       // Set the source of the publication and whether it's a page or post for tracking and later processing
       obj.source = 'Ghost';
-      obj.contentType = contentType === 'posts' ? 'post' : 'page';
+      const singularContentType = contentType.slice(0, -1);
+      obj.contentType = singularContentType;
 
       // Set a default feature image for posts if one doesn't exist
       if (contentType === 'posts' && !obj.feature_image)
@@ -70,7 +71,7 @@ const processBatch = async ({
         obj.image_dimensions = { ...obj.image_dimensions };
         obj.image_dimensions.feature_image = await getImageDimensions(
           obj.feature_image,
-          `Ghost post feature image: ${obj.title}`
+          `Ghost ${singularContentType} feature image: ${obj.title}`
         );
       }
 

--- a/utils/modify-html-content.js
+++ b/utils/modify-html-content.js
@@ -38,7 +38,10 @@ const modifyHTMLContent = async ({ postContent, postTitle, source }) => {
     images.map(async image => {
       // To do: swap out the image URLs here once we have them auto synced
       // with an S3 bucket
-      const { width, height } = await getImageDimensions(image.src, postTitle);
+      const { width, height } = await getImageDimensions(
+        image.src,
+        `Body image in ${postTitle}: ${image.src}`
+      );
 
       image.setAttribute('width', width);
       image.setAttribute('height', height);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR uses node-cache during builds to cache all image dimensions. There are also some minor changes to improve error logging for images where we aren't able to get the width / height for some reason.

In my testing, caching all image dimensions with node-cache doesn't seem to increase the build times in any significant way. I've tested with a handful of live builds for Chinese, Spanish, and Japanese News, and build times are at about 40-60ms per page depending on my network and other factors. 

By introducing node-cache here we can use the module to cache data about original authors and posts in a follow up PR.