### PR TITLE
fix: improve error handling for the original author and translator feature

### DIFF
--- a/utils/ghost/process-batch.js
+++ b/utils/ghost/process-batch.js
@@ -144,11 +144,14 @@ const processBatch = async ({
         const originalPostData = await originalPostHandler(
           [obj.codeinjection_head, obj.codeinjection_foot]
             .filter(Boolean)
-            .join()
+            .join(),
+          obj.title
         );
 
-        obj.original_post = originalPostData;
-        obj.html = originalPostData?.introHTML + obj.html;
+        if (originalPostData) {
+          obj.original_post = originalPostData;
+          obj.html = originalPostData.introHTML + obj.html;
+        }
       }
 
       // Stash original excerpt and escape for structured data.

--- a/utils/hashnode/process-batch.js
+++ b/utils/hashnode/process-batch.js
@@ -118,11 +118,15 @@ const processBatch = async ({
         // it doesn't have to included in the final returned object.
         if (obj?.seo?.description) {
           const originalPostData = await originalPostHandler(
-            obj.seo.description
+            obj.seo.description,
+            obj.title
           );
 
-          obj.original_post = originalPostData;
-          obj.html = originalPostData?.introHTML + obj.html;
+          if (originalPostData) {
+            obj.original_post = originalPostData;
+            obj.html = originalPostData.introHTML + obj.html;
+          }
+
           delete obj.seo;
         }
       }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR improves error handling and reporting for the original author and translator feature. This should prevent builds from breaking when the URL for `fCCOriginalPost` is malformed, set to an empty string, and so on.

This will also prevent unhelpful intro HTML from being appended to the beginning of articles in case of the errors mentioned above.