### PR TITLE
fix: add Hashnode env vars to English GH action

### DIFF
--- a/.github/workflows/deploy-eng.yml
+++ b/.github/workflows/deploy-eng.yml
@@ -71,6 +71,9 @@ jobs:
       GOOGLE_ADSENSE_DATA_AD_CLIENT: ${{ secrets.GOOGLE_ADSENSE_DATA_AD_CLIENT }}
       GOOGLE_ADSENSE_DATA_AD_SLOT: ${{ secrets.GOOGLE_ADSENSE_DATA_AD_SLOT }}
 
+      HASHNODE_API_URL: ${{ secrets.HASHNODE_API_URL }}
+      ENGLISH_HASHNODE_HOST: ${{ secrets.ENGLISH_HASHNODE_HOST }}
+
       POSTS_PER_PAGE: ${{ secrets.POSTS_PER_PAGE }}
 
       SITE_DOMAIN: freecodecamp.${{ matrix.site_tlds }}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR adds a couple of missing Hashnode related environment variables to the `deploy-eng.yml` GHA file. This should allow us to pull in posts / pages from Hashnode during future builds.