### PR TITLE
feat: add redirects for slugs with underscore characters

### DIFF
--- a/config/i18n/locales/english/redirects.json
+++ b/config/i18n/locales/english/redirects.json
@@ -20,6 +20,26 @@
     "destination": "/news/about"
   },
   {
+    "source": "/nameerror-name-plot_cases_simple-is-not-defined-how-to-fix-this-python-error",
+    "destination": "/news/nameerror-name-plot-cases-simple-is-not-defined-how-to-fix-this-python-error",
+    "type": 302
+  },
+  {
+    "source": "/dns_probe_finished_nxdomain-error-solved",
+    "destination": "/news/dns-probe-finished-nxdomain-error-solved",
+    "type": 302
+  },
+  {
+    "source": "/row_number-in-sql-select-top-example-in-sql-and-sql-server2",
+    "destination": "/news/row-number-in-sql-select-top-example-in-sql-and-sql-server",
+    "type": 302
+  },
+  {
+    "source": "/how-to-use-join-and-string_agg-in-microsoft-sql-server",
+    "destination": "/news/how-to-use-join-and-string-agg-in-microsoft-sql-server",
+    "type": 302
+  },
+  {
     "source": "/html-css-handbook-for-beginners",
     "destination": "/news/the-html-handbook",
     "type": 302


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR adds redirects for a handful of articles, some of which we have already downloaded to the Ghost Post Archive repo, but can't be uploaded to Hashnode because the slugs contain underscore characters.

Here are all the articles with slugs that contain underscores:

```
{
  title: 'NameError: Name plot_cases_simple is Not Defined – How to Fix this Python Error',
  slug: 'nameerror-name-plot_cases_simple-is-not-defined-how-to-fix-this-python-error',
  author: 'Ihechikara Vincent Abba'
}
{
  title: 'dns_probe_finished_nxdomain Error [Solved]',
  slug: 'dns_probe_finished_nxdomain-error-solved',
  author: 'Kolade Chris'
}
{
  title: 'ROW_NUMBER in SQL – Select Top Example in SQL and SQL Server',
  slug: 'row_number-in-sql-select-top-example-in-sql-and-sql-server2',
  author: 'Zaira Hira'
}
{
  title: 'How to Use Join and String_agg in Microsoft SQL Server',
  slug: 'how-to-use-join-and-string_agg-in-microsoft-sql-server',
  author: 'Thanoshan MV'
}
```

All `_` characters have been replaced with a `-`. Also, the `2` at the end of `row_number-in-sql-select-top-example-in-sql-and-sql-server2` has been removed.

Once this is merged I can update the article by Thanoshan MV on Ghost so it won't cause issues with the download / upload script. We'll need to discuss how to handle staff articles that have been downloaded, but haven't been uploaded to Hashnode yet.