### PR TITLE
fix: metadata for hashnode sourced content

### DIFF
--- a/cypress/e2e/english/post/meta.cy.js
+++ b/cypress/e2e/english/post/meta.cy.js
@@ -247,224 +247,251 @@ describe('Post metadata', () => {
   });
 
   context('Hashnode sourced post', () => {
-    beforeEach(() => {
-      cy.visit('/freecodecamp-press-books-handbooks/');
-    });
+    context('General test cases', () => {
+      beforeEach(() => {
+        cy.visit('/freecodecamp-press-books-handbooks/');
+      });
 
-    it('<title>', () => {
-      cy.title().should('eq', hashnodePostExpectedMeta.title);
-    });
+      it('<title>', () => {
+        cy.title().should('eq', hashnodePostExpectedMeta.title);
+      });
 
-    it('<meta> description', () => {
-      cy.get('head meta[name="description"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.excerpt
-      );
-    });
+      it('<meta> description', () => {
+        cy.get('head meta[name="description"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.excerpt
+        );
+      });
 
-    it('<link> canonical', () => {
-      cy.get('head link[rel="canonical"]').should(
-        'have.attr',
-        'href',
-        hashnodePostExpectedMeta.url
-      );
-    });
+      it('<link> canonical', () => {
+        cy.get('head link[rel="canonical"]').should(
+          'have.attr',
+          'href',
+          hashnodePostExpectedMeta.url
+        );
+      });
 
-    it('<meta> generator', () => {
-      cy.get('head meta[name="generator"]').should(
-        'have.attr',
-        'content',
-        commonExpectedMeta.generator
-      );
-    });
+      it('<meta> generator', () => {
+        cy.get('head meta[name="generator"]').should(
+          'have.attr',
+          'content',
+          commonExpectedMeta.generator
+        );
+      });
 
-    it('<meta> og:site_name', () => {
-      cy.get('head meta[property="og:site_name"]').should(
-        'have.attr',
-        'content',
-        commonExpectedMeta.siteName
-      );
-    });
+      it('<meta> og:site_name', () => {
+        cy.get('head meta[property="og:site_name"]').should(
+          'have.attr',
+          'content',
+          commonExpectedMeta.siteName
+        );
+      });
 
-    it('<meta> og:type', () => {
-      cy.get('head meta[property="og:type"]').should(
-        'have.attr',
-        'content',
-        'article'
-      );
-    });
+      it('<meta> og:type', () => {
+        cy.get('head meta[property="og:type"]').should(
+          'have.attr',
+          'content',
+          'article'
+        );
+      });
 
-    it('<meta> og:title', () => {
-      cy.get('head meta[property="og:title"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.title
-      );
-    });
+      it('<meta> og:title', () => {
+        cy.get('head meta[property="og:title"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.title
+        );
+      });
 
-    it('<meta> og:description', () => {
-      cy.get('head meta[property="og:description"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.excerpt
-      );
-    });
+      it('<meta> og:description', () => {
+        cy.get('head meta[property="og:description"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.excerpt
+        );
+      });
 
-    it('<meta> og:url', () => {
-      cy.get('head meta[property="og:url"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.url
-      );
-    });
+      it('<meta> og:url', () => {
+        cy.get('head meta[property="og:url"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.url
+        );
+      });
 
-    it('<meta> og:image', () => {
-      cy.get('head meta[property="og:image"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.image.url
-      );
-    });
+      it('<meta> og:image', () => {
+        cy.get('head meta[property="og:image"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.image.url
+        );
+      });
 
-    it('<meta> og:image:width', () => {
-      cy.get('head meta[property="og:image:width"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.image.width
-      );
-    });
+      it('<meta> og:image:width', () => {
+        cy.get('head meta[property="og:image:width"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.image.width
+        );
+      });
 
-    it('<meta> og:image:height', () => {
-      cy.get('head meta[property="og:image:height"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.image.height
-      );
-    });
+      it('<meta> og:image:height', () => {
+        cy.get('head meta[property="og:image:height"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.image.height
+        );
+      });
 
-    it('<meta> article:published_time', () => {
-      cy.get('head meta[property="article:published_time"]').should($metaEl => {
-        const publishedTimeISO = new Date(
-          $metaEl.attr('content')
-        ).toISOString();
+      it('<meta> article:published_time', () => {
+        cy.get('head meta[property="article:published_time"]').should(
+          $metaEl => {
+            const publishedTimeISO = new Date(
+              $metaEl.attr('content')
+            ).toISOString();
 
-        expect(publishedTimeISO).to.equal('2023-08-29T15:00:00.000Z');
+            expect(publishedTimeISO).to.equal('2023-08-29T15:00:00.000Z');
+          }
+        );
+      });
+
+      it('<meta> article:modified_time (for post that has been updated)', () => {
+        cy.get('head meta[property="article:modified_time"]').should(
+          $metaEl => {
+            const modifiedTimeISO = new Date(
+              $metaEl.attr('content')
+            ).toISOString();
+
+            expect(modifiedTimeISO).to.equal('2024-04-01T12:58:13.648Z');
+          }
+        );
+      });
+
+      // This article has two tags
+      it('<meta> article:tag', () => {
+        cy.get('head meta[property="article:tag"]').then($metaEls => {
+          const tags = Array.from($metaEls).map(metaEl => metaEl.content);
+
+          expect(tags).to.have.members([
+            'freeCodeCamp.org',
+            'technical writing'
+          ]);
+        });
+      });
+
+      it('<meta> article:publisher', () => {
+        cy.get('head meta[property="article:publisher"]').should(
+          'have.attr',
+          'content',
+          commonExpectedMeta.facebook.url
+        );
+      });
+
+      it('<meta> twitter:card', () => {
+        cy.get('head meta[name="twitter:card"]').should(
+          'have.attr',
+          'content',
+          commonExpectedMeta.twitter.cardType
+        );
+      });
+
+      it('<meta> twitter:title', () => {
+        cy.get('head meta[name="twitter:title"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.title
+        );
+      });
+
+      it('<meta> twitter:description', () => {
+        cy.get('head meta[name="twitter:description"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.excerpt
+        );
+      });
+
+      it('<meta> twitter:url', () => {
+        cy.get('head meta[name="twitter:url"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.url
+        );
+      });
+
+      it('<meta> twitter:image', () => {
+        cy.get('head meta[name="twitter:image"]').should(
+          'have.attr',
+          'content',
+          hashnodePostExpectedMeta.image.url
+        );
+      });
+
+      it('<meta> twitter:label1', () => {
+        cy.get('head meta[name="twitter:label1"]').should(
+          'have.attr',
+          'content',
+          commonExpectedMeta.twitter.label1
+        );
+      });
+
+      it('<meta> twitter:data1', () => {
+        cy.get('head meta[name="twitter:data1"]').should(
+          'have.attr',
+          'content',
+          'Abigail Rennemeyer'
+        );
+      });
+
+      it('<meta> twitter:label2', () => {
+        cy.get('head meta[name="twitter:label2"]').should(
+          'have.attr',
+          'content',
+          commonExpectedMeta.twitter.label2
+        );
+      });
+
+      // This article has two tags, combined into a single content string
+      it('<meta> twitter:data2', () => {
+        cy.get('head meta[name="twitter:data2"]').should(
+          'have.attr',
+          'content',
+          'freeCodeCamp.org, technical writing' // Note: Hashnode's freeCodeCamp tag has different text than the one on Ghost
+        );
+      });
+
+      it('<meta> twitter:site', () => {
+        cy.get('head meta[name="twitter:site"]').should(
+          'have.attr',
+          'content',
+          commonExpectedMeta.twitter.username
+        );
+      });
+
+      it('<meta> twitter:creator', () => {
+        cy.get('head meta[name="twitter:creator"]').should(
+          'have.attr',
+          'content',
+          '@abbeyrenn'
+        );
       });
     });
 
-    it('<meta> article:modified_time', () => {
-      cy.get('head meta[property="article:modified_time"]').should($metaEl => {
-        const modifiedTimeISO = new Date($metaEl.attr('content')).toISOString();
+    context('Other test cases', () => {
+      it('<meta> article:modified_time (for post that has **not** been updated)', () => {
+        cy.visit('/hashnode-no-feature-image/');
 
-        expect(modifiedTimeISO).to.equal('2024-04-01T12:58:13.648Z');
+        cy.get('head meta[property="article:modified_time"]').should(
+          $metaEl => {
+            const modifiedTimeISO = new Date(
+              $metaEl.attr('content')
+            ).toISOString();
+
+            expect(modifiedTimeISO).to.equal('2024-04-16T07:41:57.015Z');
+          }
+        );
       });
-    });
-
-    // This article has two tags
-    it('<meta> article:tag', () => {
-      cy.get('head meta[property="article:tag"]').then($metaEls => {
-        const tags = Array.from($metaEls).map(metaEl => metaEl.content);
-
-        expect(tags).to.have.members(['freeCodeCamp.org', 'technical writing']);
-      });
-    });
-
-    it('<meta> article:publisher', () => {
-      cy.get('head meta[property="article:publisher"]').should(
-        'have.attr',
-        'content',
-        commonExpectedMeta.facebook.url
-      );
-    });
-
-    it('<meta> twitter:card', () => {
-      cy.get('head meta[name="twitter:card"]').should(
-        'have.attr',
-        'content',
-        commonExpectedMeta.twitter.cardType
-      );
-    });
-
-    it('<meta> twitter:title', () => {
-      cy.get('head meta[name="twitter:title"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.title
-      );
-    });
-
-    it('<meta> twitter:description', () => {
-      cy.get('head meta[name="twitter:description"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.excerpt
-      );
-    });
-
-    it('<meta> twitter:url', () => {
-      cy.get('head meta[name="twitter:url"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.url
-      );
-    });
-
-    it('<meta> twitter:image', () => {
-      cy.get('head meta[name="twitter:image"]').should(
-        'have.attr',
-        'content',
-        hashnodePostExpectedMeta.image.url
-      );
-    });
-
-    it('<meta> twitter:label1', () => {
-      cy.get('head meta[name="twitter:label1"]').should(
-        'have.attr',
-        'content',
-        commonExpectedMeta.twitter.label1
-      );
-    });
-
-    it('<meta> twitter:data1', () => {
-      cy.get('head meta[name="twitter:data1"]').should(
-        'have.attr',
-        'content',
-        'Abigail Rennemeyer'
-      );
-    });
-
-    it('<meta> twitter:label2', () => {
-      cy.get('head meta[name="twitter:label2"]').should(
-        'have.attr',
-        'content',
-        commonExpectedMeta.twitter.label2
-      );
-    });
-
-    // This article has two tags, combined into a single content string
-    it('<meta> twitter:data2', () => {
-      cy.get('head meta[name="twitter:data2"]').should(
-        'have.attr',
-        'content',
-        'freeCodeCamp.org, technical writing' // Note: Hashnode's freeCodeCamp tag has different text than the one on Ghost
-      );
-    });
-
-    it('<meta> twitter:site', () => {
-      cy.get('head meta[name="twitter:site"]').should(
-        'have.attr',
-        'content',
-        commonExpectedMeta.twitter.username
-      );
-    });
-
-    it('<meta> twitter:creator', () => {
-      cy.get('head meta[name="twitter:creator"]').should(
-        'have.attr',
-        'content',
-        '@abbeyrenn'
-      );
     });
   });
 });

--- a/cypress/e2e/english/post/structured-data.cy.js
+++ b/cypress/e2e/english/post/structured-data.cy.js
@@ -1,5 +1,3 @@
-const { before } = require('lodash');
-
 describe('Post structured data (JSON-LD)', () => {
   const commonExpectedJsonLd = require('../../../fixtures/common-expected-json-ld.json');
   const ghostPostExpectedJsonLd = {
@@ -61,52 +59,52 @@ describe('Post structured data (JSON-LD)', () => {
   };
   let jsonLdObj;
 
-  // context('Ghost sourced posts', () => {
-  //   beforeEach(() => {
-  //     cy.visit('/announcing-rust-course-replit-web/');
+  context('Ghost sourced posts', () => {
+    beforeEach(() => {
+      cy.visit('/announcing-rust-course-replit-web/');
 
-  //     jsonLdObj = cy
-  //       .get('head script[type="application/ld+json"]')
-  //       .then($script => {
-  //         jsonLdObj = JSON.parse($script.text());
-  //       });
-  //   });
+      jsonLdObj = cy
+        .get('head script[type="application/ld+json"]')
+        .then($script => {
+          jsonLdObj = JSON.parse($script.text());
+        });
+    });
 
-  //   it('matches the expected base values', () => {
-  //     expect(jsonLdObj['@context']).to.equal(commonExpectedJsonLd['@context']);
-  //     expect(jsonLdObj['@type']).to.equal(ghostPostExpectedJsonLd['@type']);
-  //     expect(jsonLdObj.url).to.equal(ghostPostExpectedJsonLd.url);
-  //     expect(jsonLdObj.datePublished).to.equal(
-  //       ghostPostExpectedJsonLd.datePublished
-  //     );
-  //     expect(jsonLdObj.dateModified).to.equal(
-  //       ghostPostExpectedJsonLd.dateModified
-  //     );
-  //     expect(jsonLdObj.description).to.equal(
-  //       ghostPostExpectedJsonLd.description
-  //     );
-  //     expect(jsonLdObj.headline).to.equal(ghostPostExpectedJsonLd.headline);
-  //     expect(jsonLdObj.keywords).to.equal(ghostPostExpectedJsonLd.keywords);
-  //   });
+    it('matches the expected base values', () => {
+      expect(jsonLdObj['@context']).to.equal(commonExpectedJsonLd['@context']);
+      expect(jsonLdObj['@type']).to.equal(ghostPostExpectedJsonLd['@type']);
+      expect(jsonLdObj.url).to.equal(ghostPostExpectedJsonLd.url);
+      expect(jsonLdObj.datePublished).to.equal(
+        ghostPostExpectedJsonLd.datePublished
+      );
+      expect(jsonLdObj.dateModified).to.equal(
+        ghostPostExpectedJsonLd.dateModified
+      );
+      expect(jsonLdObj.description).to.equal(
+        ghostPostExpectedJsonLd.description
+      );
+      expect(jsonLdObj.headline).to.equal(ghostPostExpectedJsonLd.headline);
+      expect(jsonLdObj.keywords).to.equal(ghostPostExpectedJsonLd.keywords);
+    });
 
-  //   it('matches the expected publisher values', () => {
-  //     expect(jsonLdObj.publisher).to.deep.equal(commonExpectedJsonLd.publisher);
-  //   });
+    it('matches the expected publisher values', () => {
+      expect(jsonLdObj.publisher).to.deep.equal(commonExpectedJsonLd.publisher);
+    });
 
-  //   it('matches the expected image values', () => {
-  //     expect(jsonLdObj.image).to.deep.equal(ghostPostExpectedJsonLd.image);
-  //   });
+    it('matches the expected image values', () => {
+      expect(jsonLdObj.image).to.deep.equal(ghostPostExpectedJsonLd.image);
+    });
 
-  //   it('matches the expected mainEntityOfPage values', () => {
-  //     expect(jsonLdObj.mainEntityOfPage).to.deep.equal(
-  //       commonExpectedJsonLd.mainEntityOfPage
-  //     );
-  //   });
+    it('matches the expected mainEntityOfPage values', () => {
+      expect(jsonLdObj.mainEntityOfPage).to.deep.equal(
+        commonExpectedJsonLd.mainEntityOfPage
+      );
+    });
 
-  //   it('matches the expected author values', () => {
-  //     expect(jsonLdObj.author).to.deep.equal(ghostPostExpectedJsonLd.author);
-  //   });
-  // });
+    it('matches the expected author values', () => {
+      expect(jsonLdObj.author).to.deep.equal(ghostPostExpectedJsonLd.author);
+    });
+  });
 
   context('Hashnode sourced posts', () => {
     context('General test cases', () => {

--- a/cypress/e2e/english/post/structured-data.cy.js
+++ b/cypress/e2e/english/post/structured-data.cy.js
@@ -1,3 +1,5 @@
+const { before } = require('lodash');
+
 describe('Post structured data (JSON-LD)', () => {
   const commonExpectedJsonLd = require('../../../fixtures/common-expected-json-ld.json');
   const ghostPostExpectedJsonLd = {
@@ -59,97 +61,128 @@ describe('Post structured data (JSON-LD)', () => {
   };
   let jsonLdObj;
 
-  context('Ghost sourced posts', () => {
-    beforeEach(() => {
-      cy.visit('/announcing-rust-course-replit-web/');
+  // context('Ghost sourced posts', () => {
+  //   beforeEach(() => {
+  //     cy.visit('/announcing-rust-course-replit-web/');
 
-      jsonLdObj = cy
-        .get('head script[type="application/ld+json"]')
-        .then($script => {
-          jsonLdObj = JSON.parse($script.text());
-        });
-    });
+  //     jsonLdObj = cy
+  //       .get('head script[type="application/ld+json"]')
+  //       .then($script => {
+  //         jsonLdObj = JSON.parse($script.text());
+  //       });
+  //   });
 
-    it('matches the expected base values', () => {
-      expect(jsonLdObj['@context']).to.equal(commonExpectedJsonLd['@context']);
-      expect(jsonLdObj['@type']).to.equal(ghostPostExpectedJsonLd['@type']);
-      expect(jsonLdObj.url).to.equal(ghostPostExpectedJsonLd.url);
-      expect(jsonLdObj.datePublished).to.equal(
-        ghostPostExpectedJsonLd.datePublished
-      );
-      expect(jsonLdObj.dateModified).to.equal(
-        ghostPostExpectedJsonLd.dateModified
-      );
-      expect(jsonLdObj.description).to.equal(
-        ghostPostExpectedJsonLd.description
-      );
-      expect(jsonLdObj.headline).to.equal(ghostPostExpectedJsonLd.headline);
-      expect(jsonLdObj.keywords).to.equal(ghostPostExpectedJsonLd.keywords);
-    });
+  //   it('matches the expected base values', () => {
+  //     expect(jsonLdObj['@context']).to.equal(commonExpectedJsonLd['@context']);
+  //     expect(jsonLdObj['@type']).to.equal(ghostPostExpectedJsonLd['@type']);
+  //     expect(jsonLdObj.url).to.equal(ghostPostExpectedJsonLd.url);
+  //     expect(jsonLdObj.datePublished).to.equal(
+  //       ghostPostExpectedJsonLd.datePublished
+  //     );
+  //     expect(jsonLdObj.dateModified).to.equal(
+  //       ghostPostExpectedJsonLd.dateModified
+  //     );
+  //     expect(jsonLdObj.description).to.equal(
+  //       ghostPostExpectedJsonLd.description
+  //     );
+  //     expect(jsonLdObj.headline).to.equal(ghostPostExpectedJsonLd.headline);
+  //     expect(jsonLdObj.keywords).to.equal(ghostPostExpectedJsonLd.keywords);
+  //   });
 
-    it('matches the expected publisher values', () => {
-      expect(jsonLdObj.publisher).to.deep.equal(commonExpectedJsonLd.publisher);
-    });
+  //   it('matches the expected publisher values', () => {
+  //     expect(jsonLdObj.publisher).to.deep.equal(commonExpectedJsonLd.publisher);
+  //   });
 
-    it('matches the expected image values', () => {
-      expect(jsonLdObj.image).to.deep.equal(ghostPostExpectedJsonLd.image);
-    });
+  //   it('matches the expected image values', () => {
+  //     expect(jsonLdObj.image).to.deep.equal(ghostPostExpectedJsonLd.image);
+  //   });
 
-    it('matches the expected mainEntityOfPage values', () => {
-      expect(jsonLdObj.mainEntityOfPage).to.deep.equal(
-        commonExpectedJsonLd.mainEntityOfPage
-      );
-    });
+  //   it('matches the expected mainEntityOfPage values', () => {
+  //     expect(jsonLdObj.mainEntityOfPage).to.deep.equal(
+  //       commonExpectedJsonLd.mainEntityOfPage
+  //     );
+  //   });
 
-    it('matches the expected author values', () => {
-      expect(jsonLdObj.author).to.deep.equal(ghostPostExpectedJsonLd.author);
-    });
-  });
+  //   it('matches the expected author values', () => {
+  //     expect(jsonLdObj.author).to.deep.equal(ghostPostExpectedJsonLd.author);
+  //   });
+  // });
 
   context('Hashnode sourced posts', () => {
-    beforeEach(() => {
-      cy.visit('/freecodecamp-press-books-handbooks/');
+    context('General test cases', () => {
+      beforeEach(() => {
+        cy.visit('/freecodecamp-press-books-handbooks/');
 
-      jsonLdObj = cy
-        .get('head script[type="application/ld+json"]')
-        .then($script => {
-          jsonLdObj = JSON.parse($script.text());
-        });
+        jsonLdObj = cy
+          .get('head script[type="application/ld+json"]')
+          .then($script => {
+            jsonLdObj = JSON.parse($script.text());
+          });
+      });
+
+      it('matches the expected base values', () => {
+        expect(jsonLdObj['@context']).to.equal(
+          commonExpectedJsonLd['@context']
+        );
+        expect(jsonLdObj['@type']).to.equal(
+          hashnodePostExpectedJsonLd['@type']
+        );
+        expect(jsonLdObj.url).to.equal(hashnodePostExpectedJsonLd.url);
+        expect(jsonLdObj.datePublished).to.equal(
+          hashnodePostExpectedJsonLd.datePublished
+        );
+        expect(jsonLdObj.dateModified).to.equal(
+          hashnodePostExpectedJsonLd.dateModified
+        );
+        expect(jsonLdObj.description).to.equal(
+          hashnodePostExpectedJsonLd.description
+        );
+        expect(jsonLdObj.headline).to.equal(
+          hashnodePostExpectedJsonLd.headline
+        );
+        expect(jsonLdObj.keywords).to.equal(
+          hashnodePostExpectedJsonLd.keywords
+        );
+      });
+
+      it('matches the expected publisher values', () => {
+        expect(jsonLdObj.publisher).to.deep.equal(
+          commonExpectedJsonLd.publisher
+        );
+      });
+
+      it('matches the expected image values', () => {
+        expect(jsonLdObj.image).to.deep.equal(hashnodePostExpectedJsonLd.image);
+      });
+
+      it('matches the expected mainEntityOfPage values', () => {
+        expect(jsonLdObj.mainEntityOfPage).to.deep.equal(
+          commonExpectedJsonLd.mainEntityOfPage
+        );
+      });
+
+      it('matches the expected author values', () => {
+        expect(jsonLdObj.author).to.deep.equal(
+          hashnodePostExpectedJsonLd.author
+        );
+      });
     });
 
-    it('matches the expected base values', () => {
-      expect(jsonLdObj['@context']).to.equal(commonExpectedJsonLd['@context']);
-      expect(jsonLdObj['@type']).to.equal(hashnodePostExpectedJsonLd['@type']);
-      expect(jsonLdObj.url).to.equal(hashnodePostExpectedJsonLd.url);
-      expect(jsonLdObj.datePublished).to.equal(
-        hashnodePostExpectedJsonLd.datePublished
-      );
-      expect(jsonLdObj.dateModified).to.equal(
-        hashnodePostExpectedJsonLd.dateModified
-      );
-      expect(jsonLdObj.description).to.equal(
-        hashnodePostExpectedJsonLd.description
-      );
-      expect(jsonLdObj.headline).to.equal(hashnodePostExpectedJsonLd.headline);
-      expect(jsonLdObj.keywords).to.equal(hashnodePostExpectedJsonLd.keywords);
-    });
+    context('Other test cases', () => {
+      beforeEach(() => {
+        cy.visit('/hashnode-no-feature-image/');
 
-    it('matches the expected publisher values', () => {
-      expect(jsonLdObj.publisher).to.deep.equal(commonExpectedJsonLd.publisher);
-    });
+        jsonLdObj = cy
+          .get('head script[type="application/ld+json"]')
+          .then($script => {
+            jsonLdObj = JSON.parse($script.text());
+          });
+      });
 
-    it('matches the expected image values', () => {
-      expect(jsonLdObj.image).to.deep.equal(hashnodePostExpectedJsonLd.image);
-    });
-
-    it('matches the expected mainEntityOfPage values', () => {
-      expect(jsonLdObj.mainEntityOfPage).to.deep.equal(
-        commonExpectedJsonLd.mainEntityOfPage
-      );
-    });
-
-    it('matches the expected author values', () => {
-      expect(jsonLdObj.author).to.deep.equal(hashnodePostExpectedJsonLd.author);
+      it('A post that has not been updated should not have dateModified in its structured data', () => {
+        expect(jsonLdObj.datePublished).to.equal('2024-04-16T07:41:57.015Z');
+        expect(jsonLdObj.dateModified).to.equal('2024-04-16T07:41:57.015Z');
+      });
     });
   });
 });

--- a/src/sitemaps/sitemaps.test.js
+++ b/src/sitemaps/sitemaps.test.js
@@ -1,5 +1,5 @@
 const libxmljs = require('libxmljs');
-const fs = require('fs');
+const { readFileSync } = require('graceful-fs');
 const { join } = require('path');
 
 const sitemapFilenames = [
@@ -16,13 +16,10 @@ describe('Sitemap tests:', () => {
     sitemapFilenames.forEach(sitemapFilename => {
       test(`${sitemapFilename} is valid`, () => {
         try {
-          const sitemap = fs.readFileSync(
-            join(distPath, sitemapFilename),
-            'utf8'
-          );
+          const sitemap = readFileSync(join(distPath, sitemapFilename), 'utf8');
           const schemaFilename =
             sitemapFilename === 'sitemap.xml' ? 'siteindex.xsd' : 'sitemap.xsd';
-          const schema = fs.readFileSync(
+          const schema = readFileSync(
             join(__dirname, `./schemas/${schemaFilename}`),
             'utf8'
           );
@@ -41,6 +38,40 @@ describe('Sitemap tests:', () => {
           // Throw error again to fail test if a sitemap cannot be parsed correctly
           throw new Error(err);
         }
+      });
+    });
+  });
+
+  describe('Posts sitemap', () => {
+    describe('Last modified date', () => {
+      test('All posts should have a valid last modified date', () => {
+        const postsSitemap = readFileSync(
+          join(distPath, 'sitemap-posts.xml'),
+          'utf8'
+        );
+        const postsSitemapDoc = libxmljs.parseXml(postsSitemap);
+        const postURLNodes = postsSitemapDoc
+          .root()
+          .childNodes()
+          .filter(node => {
+            return node.name() === 'url';
+          });
+        const lastmodDates = postURLNodes
+          .map(node => {
+            return node
+              .childNodes()
+              .filter(node => node.name() === 'lastmod')
+              .map(node => node.text());
+          })
+          .flat();
+
+        // Ensure all posts have a last modified date
+        expect(lastmodDates).toHaveLength(postURLNodes.length);
+
+        // Ensure all last modified dates are valid dates
+        lastmodDates.forEach(date => {
+          expect(new Date(date)).toBeInstanceOf(Date);
+        });
       });
     });
   });

--- a/utils/hashnode/process-batch.js
+++ b/utils/hashnode/process-batch.js
@@ -27,6 +27,7 @@ const processBatch = async ({
         postTitle: obj.title,
         source: obj.source
       });
+      delete obj.content;
 
       // Hashnode pages don't have a brief that we can cast as an excerpt or original_excerpt,
       // so we strip the HTML tags from the body text to generate a brief for SEO and structured data.
@@ -107,7 +108,7 @@ const processBatch = async ({
         });
 
         obj.published_at = obj.publishedAt;
-        obj.updated_at = obj.updatedAt;
+        obj.updated_at = obj.updatedAt ? obj.updatedAt : obj.publishedAt;
         obj.reading_time = obj.readTimeInMinutes;
         delete obj.publishedAt;
         delete obj.updatedAt;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR uses `pubishedAt` as a default for Hasnode souced posts that don't have an `updatedAt` value. It also adds some tests to verify that each post has an expected date value.