### PR TITLE
Feat/copyable table content headers

### DIFF
--- a/src/_includes/assets/js/copyable-links.js
+++ b/src/_includes/assets/js/copyable-links.js
@@ -1,6 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
   const headers = document.querySelectorAll('h1, h2, h3');
-  console.log(headers);
   headers.forEach(header => {
     const Link = document.createElement('a');
     Link.href = `#${header.id}`;

--- a/src/_includes/assets/js/copyable-links.js
+++ b/src/_includes/assets/js/copyable-links.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const headers = document.querySelectorAll('h1, h2, h3');
+  console.log(headers);
+  headers.forEach(header => {
+    const Link = document.createElement('a');
+    Link.href = `#${header.id}`;
+    Link.classList.add('navigationHead');
+    Link.ariaLabel = 'Click to copy header link';
+
+    header.parentNode?.insertBefore(Link, header);
+    Link.appendChild(header);
+    Link.addEventListener('click', e => {
+      e.preventDefault();
+      navigator.clipboard
+        .writeText(`${window.location.href.split('#')[0]}#${header.id}`)
+        .then(() => alert('Link copied to clipboard!'))
+        .catch(err => console.error('Failed to copy!', err));
+    });
+  });
+});

--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -48,6 +48,7 @@
             {% include "assets/js/search-bar.js" %}
             {% include "assets/js/client-dayjs.js" %}
             {% include "assets/js/cookie-checker.js" %}
+            {% include "assets/js/copyable-links.js" %}
         {% endset %}
         <script>{{ js | jsMin | safe }}</script>
 

--- a/src/_includes/layouts/doc.njk
+++ b/src/_includes/layouts/doc.njk
@@ -9,6 +9,7 @@
     {% include "partials/prism.njk" %}
 {% endblock %}
 
+
 {% block content %}
     <main id="site-main" class="page-template site-main outer">
         <div class="inner">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #518

<!-- Feel free to add any additional description of changes below this line -->
While it probably wasn't exactly what was intended, I believe this suitably does the job. This creates a link with a screen reader label that has the header element inside of the link. If a link is buried inside of what was meant to be clicked, it won't work. 

I'm not sure how I feel about alerts, but I didn't quite feel comfortable enough to create tool tips for this. 