### PR TITLE
fix: replace ghost site settings object with defaults

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -1,4 +1,3 @@
-const { ghostAPI } = require('../../utils/api');
 const getImageDimensions = require('../../utils/get-image-dimensions');
 const {
   convertToLocalizedString,
@@ -14,43 +13,34 @@ const getTwitterProfile = url => url.replace('https://twitter.com/', '@');
 const twitterURL = translate('links:twitter');
 const twitterProfile =
   twitterURL !== 'twitter' ? getTwitterProfile(twitterURL) : '@freecodecamp';
+const logoURL =
+  'https://cdn.freecodecamp.org/platform/universal/fcc_primary.svg';
+const coverImageURL =
+  'https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png';
+const iconURL = 'https://cdn.freecodecamp.org/universal/favicons/favicon.ico';
 
 module.exports = async () => {
-  // TODO: Combine sensible defaults for all locales here and make sure any
-  // meta descriptions, tags, and so on have been moved to the i18n files and
-  // are being used in the templates
-  const site = await ghostAPI.settings
-    .browse({
-      include: 'url'
-    })
-    .catch(err => {
-      console.error(err);
-    });
-
-  site.url = siteURL;
-  site.lang = currentLocale_i18nISOCode.toLowerCase();
-
-  const logoUrl =
-    'https://cdn.freecodecamp.org/platform/universal/fcc_primary.svg';
-  site.logo = logoUrl;
-
-  const coverImageUrl =
-    'https://cdn.freecodecamp.org/platform/universal/fcc_meta_1920X1080-indigo.png';
-  site.cover_image = coverImageUrl;
-  site.og_image = coverImageUrl;
-  site.twitter_image = coverImageUrl;
-
-  const iconUrl = 'https://cdn.freecodecamp.org/universal/favicons/favicon.ico';
-  site.icon = iconUrl;
+  const site = {
+    url: siteURL,
+    lang: currentLocale_i18nISOCode.toLowerCase(),
+    title: 'freeCodeCamp.org',
+    facebook: 'https://www.facebook.com/freecodecamp',
+    twitter: twitterProfile,
+    logo: logoURL,
+    cover_image: coverImageURL,
+    og_image: coverImageURL,
+    twitter_image: coverImageURL,
+    iconURL: iconURL
+  };
 
   // Determine image dimensions before server runs for structured data
   const logoDimensions = await getImageDimensions(
-    logoUrl,
-    `Site logo: ${logoUrl}`
+    logoURL,
+    `Site logo: ${logoURL}`
   );
   const coverImageDimensions = await getImageDimensions(
-    coverImageUrl,
-    `Site cover image: ${coverImageUrl}`
+    coverImageURL,
+    `Site cover image: ${coverImageURL}`
   );
 
   site.image_dimensions = {
@@ -63,14 +53,6 @@ module.exports = async () => {
       height: coverImageDimensions.height
     }
   };
-
-  // Set default title across all publications
-  site.title = 'freeCodeCamp.org';
-
-  // Set default Facebook account, and set Twitter account
-  // based on UI locale
-  site.facebook = 'https://www.facebook.com/freecodecamp';
-  site.twitter = twitterProfile;
 
   // Dynamic search bar placeholder number
   const roundedTotalRecords = await getRoundedTotalRecords();


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This removes the dependency on getting a site settings object from the Ghost API and replaces it with a default site object, which should enable all builds again.