### PR TITLE
fix: pin dependency versions and adjust lint staged script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "probe-image-size": "7.2.3",
         "shx": "0.3.4",
         "terser": "5.32.0",
-        "typescript": "^5.5.4"
+        "typescript": "5.5.4"
       },
       "engines": {
         "node": ">=18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "eslint-utils": "3.0.0",
         "get-video-id": "4.1.7",
         "graceful-fs": "4.2.11",
-        "graphql-request": "^6.1.0",
+        "graphql-request": "6.1.0",
         "husky": "9.1.5",
         "i18next": "23.15.1",
         "i18next-fs-backend": "2.3.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "probe-image-size": "7.2.3",
     "shx": "0.3.4",
     "terser": "5.32.0",
-    "typescript": "^5.5.4"
+    "typescript": "5.5.4"
   },
   "lint-staged": {
     "!(*.ts)": "prettier --write --ignore-unknown",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   "lint-staged": {
     "!(*.ts)": "prettier --write --ignore-unknown",
     "*.ts": [
-      "npm run type-check",
+      "bash -c 'npm run type-check'",
       "prettier --write --ignore-unknown"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "eslint-utils": "3.0.0",
     "get-video-id": "4.1.7",
     "graceful-fs": "4.2.11",
-    "graphql-request": "^6.1.0",
+    "graphql-request": "6.1.0",
     "husky": "9.1.5",
     "i18next": "23.15.1",
     "i18next-fs-backend": "2.3.2",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Minor changes with pinned dependencies.

The more significant change is the update to the `lint-staged` script, which fixes the Husky pre-commit step on my machine whenever TS files are updated. I've found that this is important for [this PR](https://github.com/freeCodeCamp/news/pull/984) now that the Cypress tests have been migrated to TypeScript.