### PR TITLE
fix: missing favicon

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -30,7 +30,7 @@ module.exports = async () => {
     cover_image: coverImageURL,
     og_image: coverImageURL,
     twitter_image: coverImageURL,
-    iconURL: iconURL
+    icon: iconURL
   };
 
   // Determine image dimensions before server runs for structured data


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
As of https://github.com/freeCodeCamp/news/pull/978 favicons are broken, so you just see the default icon in browser tabs when opening up News.

This was due to a key that was accidentally changed from `icon` to `iconURL` in the PR above.

This PR fixes the issue, and a test will be added in https://github.com/freeCodeCamp/news/pull/984 to prevent this in the future.