### PR TITLE
fix: remove fCC author byline

### DIFF
--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -5,6 +5,7 @@
 {% set canonicalUrl = post.path | htmlBaseUrl(site.url) %}
 {% set codeinjection_head = post.codeinjection_head %}
 {% set codeinjection_foot = post.codeinjection_foot %}
+{% set fCCAuthorRegEx = r/^freeCodeCamp(\.org)?$/ %}
 {% set primaryTag = post.tags[0] %}
 {% set adsEnabled = secrets.adsEnabled %}
 {# Include 2 ads by default for all articles. Then add 1 ad for every 2 mins of
@@ -31,7 +32,7 @@ time #}
                     <h1 class="post-full-title" data-test-label="post-full-title">{{ title }}</h1>
                 </header>
                 <div class="post-full-author-header" data-test-label="author-header-no-bio">
-                    {% if post.primary_author.name != "freeCodeCamp.org" %}
+                    {% if not fCCAuthorRegEx.test(post.primary_author.name) %}
                         {% if post.original_post.primary_author %}
                             {{ byline(post.primary_author, false, false, 'translator') }}
                             {{ byline(post.original_post.primary_author, false, false, 'author', post.original_post.locale_i18n) }}
@@ -72,7 +73,7 @@ time #}
                         {% endif %}
                     </div>
                     <hr />
-                    {% if post.primary_author.name != "freeCodeCamp.org" %}
+                    {% if not fCCAuthorRegEx.test(post.primary_author.name) %}
                         <div class="post-full-author-header" data-test-label="author-header-with-bio">
                             {% if post.original_post %}
                                 {{ byline(post.primary_author, true, true, 'translator') }}

--- a/src/_includes/partials/card.njk
+++ b/src/_includes/partials/card.njk
@@ -1,6 +1,7 @@
 {% from "partials/role-list-item.njk" import roleListItem %}
 
 {% macro card(post, index) %}
+    {% set fCCAuthorRegEx = r/^freeCodeCamp(\.org)?$/ %}
     {% set lazyLoad = true if (index >= 4) else false %}
     {% set primaryTag = post.tags[0] %}
 
@@ -40,7 +41,7 @@
                 </header>
             </div>
             <footer class="post-card-meta">
-                {% if post.primary_author.name === "freeCodeCamp.org" %}
+                {% if fCCAuthorRegEx.test(post.primary_author.name) %}
                     <time class="meta-item-single" datetime="{{ post.published_at }}">{% timeAgo post.published_at %}</time>
                 {% else %}
                     <ul class="author-list" data-test-label="author-list">


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Currently the fCC author byline is shown for articles written by staff, but also for those written by contributing authors who haven't claimed their articles that have been migrated to Hashnode. We did this after the original migration to Ghost so we could properly attribute authors with a "By (author's name)" byline at the top of each article.

While we have some logic to prevent the bylines from showing, it was broken during the migration because the fCC author on Ghost was "freeCodeCamp.org", and on Hashnode it's "freeCodeCamp".

This fix uses regex to prevent the bylines from showing up in the cards on the landing page and at the top / bottom of posts for articles assigned to freeCodeCamp.org (Ghost) or freeCodeCamp (Hashnode).

After this fix, posts assigned to "freeCodeCamp" or "freeCodeCamp.org" should look like this, with no bylines at the top or bottom of the post:

![Screenshot 2024-09-13 at 5 06 43 PM](https://github.com/user-attachments/assets/e5466c61-4e4a-4d64-aa1a-eac0c6a17973)

![Screenshot 2024-09-13 at 5 07 05 PM](https://github.com/user-attachments/assets/d9b55f3c-c262-462b-bbc0-92ae8ab57fdd)

And should only show the published date on cards:

![image](https://github.com/user-attachments/assets/4c23ae05-cbf2-42dd-9b3d-4b702d0d4133)

Mock posts and tests will be added to https://github.com/freeCodeCamp/news/pull/984 once this is merged.