### PR TITLE
fix: add @types/node package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@11ty/eleventy-plugin-rss": "1.2.0",
         "@tryghost/content-api": "1.11.21",
         "@tryghost/helpers": "1.1.90",
+        "@types/node": "22.5.5",
         "algoliasearch": "4.24.0",
         "clean-css": "5.3.3",
         "cross-env": "7.0.3",
@@ -2318,10 +2319,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.17.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.18.tgz",
-      "integrity": "sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==",
-      "dev": true
+      "version": "22.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
+      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -12210,6 +12214,12 @@
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "dev": true,
@@ -14418,10 +14428,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.17.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.18.tgz",
-      "integrity": "sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==",
-      "dev": true
+      "version": "22.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
+      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.19.2"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -21588,6 +21601,12 @@
           "dev": true
         }
       }
+    },
+    "undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@11ty/eleventy-plugin-rss": "1.2.0",
     "@tryghost/content-api": "1.11.21",
     "@tryghost/helpers": "1.1.90",
+    "@types/node": "22.5.5",
     "algoliasearch": "4.24.0",
     "clean-css": "5.3.3",
     "cross-env": "7.0.3",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to #986

<!-- Feel free to add any additional description of changes below this line -->
For some reason there's an issue with the `@types/node` dependency in #986 that results in the `Overload signatures must all be optional or required` error when type checking is run. Looking at the main TypeScript repo, they use v22.5.4 of the `@types/node` package, where the line `resolve?(specified: string, parent?: string | URL): Promise<string>;` in `node_modules/@types/node/module.d.ts` seems to be causing the issue.

Adding the latest version of the `@types/node` package here resolves this issue.

We can look into removing this as a dependency later with future TypeScript updates.