### PR TITLE
fix links to sections in the articles

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -856,7 +856,7 @@ make sure this only happens on large viewports / desktop-ish devices.
 
 .post-full-content h2:target,
 .post-full-content h3:target {
-  scroll-margin-top: calc(var(--header-height) + 0.5em);
+  scroll-margin-top: calc(var(--header-height) + 44px + 0.5em); /* 44px height of the banner */
 }
 
 .post-full-content li {


### PR DESCRIPTION
Checklist:

This PR fixes annoying issue when you have Table of Contents and links with hash to section in the article. The scrollbar offset only take into account the header but ignored the banner that is below. I report it to editorial team, not sure if anyone created an issue for this. They said they want to get this fixed.

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

Closes #528

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->


