### PR TITLE
fix: escape original post titles

### DIFF
--- a/cypress/e2e/espanol/post/original-author-translator.cy.ts
+++ b/cypress/e2e/espanol/post/original-author-translator.cy.ts
@@ -26,7 +26,7 @@ describe('Original author / translator feature (Ghost sourced)', () => {
   });
 
   context(
-    'Ghost sourced translation (Español) <> Ghost sourced original post (English)',
+    'Ghost sourced translation (Español) <> Hashnode sourced original post (English)',
     () => {
       context('Author header without bios', () => {
         it('should contain an author card and a translator card', () => {
@@ -185,7 +185,7 @@ describe('Original author / translator feature (Ghost sourced)', () => {
             .find(selectors.originalArticleLink)
             .then($el => {
               cy.wrap($el).contains(
-                'The #100DaysOfCode Challenge, its history, and why you should try it for 2021'
+                'The #100DaysOfCode Challenge, its history, and why you should try it'
               );
               expect($el.attr('href')).to.deep.equal(
                 'https://www.freecodecamp.org/news/the-crazy-history-of-the-100daysofcode-challenge-and-why-you-should-try-it-for-2018-6c89a76e298d/'

--- a/utils/original-post-handler.js
+++ b/utils/original-post-handler.js
@@ -5,6 +5,7 @@ const { JSDOM } = jsdom;
 const { getCache, setCache } = require('./cache');
 const getImageDimensions = require('./get-image-dimensions');
 const translate = require('./translate');
+const fullEscaper = require('./full-escaper');
 
 const originalPostHandler = async (originalPostFlag, translatedPostTitle) => {
   let hrefValue;
@@ -38,9 +39,9 @@ const originalPostHandler = async (originalPostFlag, translatedPostTitle) => {
       const originalPostDate = document.querySelector(
         '.post-full-meta-date'
       ).dateTime;
-      const originalPostTitle = document
-        .querySelector('.post-full-title')
-        .textContent.trim();
+      const originalPostTitle = fullEscaper(
+        document.querySelector('.post-full-title').textContent.trim()
+      );
       // Get the original author's data
       let originalAuthorObj = {};
       const originalAuthorRelativePath =


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes https://github.com/freeCodeCamp/news/issues/1018

<!-- Feel free to add any additional description of changes below this line -->
This should fix issues with HTML tags not being escaped when listing original article titles at the beginning of translated ones.