### PR TITLE
fix(i18n): use Lato and NotoSansJP fonts for Japanese

### DIFF
--- a/src/_includes/assets/css/global.css
+++ b/src/_includes/assets/css/global.css
@@ -16,6 +16,13 @@
   --gray00: #fff;
   --header-height: 38px;
   --blue-dark: #002ead;
+  /* Font */
+  --font-family-sans-serif: 'Lato', sans-serif;
+}
+
+/* Japanese Font */
+:root:lang(ja) {
+  --font-family-sans-serif: 'Lato', 'Noto Sans JP', sans-serif;
 }
 
 /* Fonts
@@ -136,7 +143,7 @@ img {
 }
 html {
   box-sizing: border-box;
-  font-family: 'Lato', sans-serif;
+  font-family: var(--font-family-sans-serif);
 
   -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
@@ -288,7 +295,7 @@ html {
 body {
   overflow-x: hidden;
   color: var(--gray90);
-  font-family: 'Lato', sans-serif;
+  font-family: var(--font-family-sans-serif);
   font-size: 1.5rem;
   line-height: 1.6em;
   font-weight: 400;

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -105,7 +105,7 @@ body {
   color: #fff;
   width: 100%;
   background: var(--theme-color);
-  font-family: 'Lato', sans-serif;
+  font-family: var(--font-family-sans-serif);
   font-display: swap;
 }
 
@@ -176,7 +176,7 @@ body {
   align-items: flex-start;
   /* overflow-y: auto; */
   font-size: 1.2em;
-  font-family: Lato, sans-serif;
+  font-family: var(--font-family-sans-serif);
   font-display: swap;
   height: var(--header-height);
   background: var(--theme-color);
@@ -498,7 +498,7 @@ a.nav-forum {
 }
 
 .post-card-excerpt {
-  font-family: 'Lato', sans-serif;
+  font-family: var(--font-family-sans-serif);
   font-display: swap;
 }
 
@@ -798,16 +798,11 @@ make sure this only happens on large viewports / desktop-ish devices.
   margin: 0 auto;
   padding: 70px 150px 0;
   min-height: 230px;
-  font-family: 'Lato', sans-serif;
+  font-family: var(--font-family-sans-serif);
   font-display: swap;
   font-size: 2.2rem;
   line-height: 1.6em;
   background: #fff;
-}
-
-/* Japanese font */
-.post-full-content:lang(ja) {
-  font-family: 'Lato', 'Noto Sans JP', sans-serif;
 }
 
 @media (max-width: 500px) {
@@ -1869,7 +1864,7 @@ p:has(mjx-container.MathJax) {
   justify-content: center;
   align-items: center;
   margin: 0 0 10px;
-  font-family: 'Lato', sans-serif;
+  font-family: var(--font-family-sans-serif);
   font-display: swap;
   font-style: italic;
 }

--- a/src/_includes/layouts/default.njk
+++ b/src/_includes/layouts/default.njk
@@ -14,10 +14,9 @@
 
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'" href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,300;0,400;0,700;1,400&family=Roboto+Mono:wght@400;700&display=swap">
         {% if site.lang === 'ja' %}
             <link rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&family=Roboto+Mono:wght@400;700&display=swap">
-        {% else %}
-            <link rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'" href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,300;0,400;0,700;1,400&family=Roboto+Mono:wght@400;700&display=swap">
         {% endif %}
 
         {# Load Prism styles and scripts only for posts / pages #}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
While I was looking at [the PR about Japanese font in the main repo](https://github.com/freeCodeCamp/freeCodeCamp/pull/56670), I realized my mistakes in this repo.

Changes:
- load both Lato and NotoSansJP when the language is set to Japanese, so that the alphabet and numbers are displayed in Lato while using NotoSansJP for other Japanese characters.
- use NotoSansJP everywhere, not only in the post body.

<details>
<summary>Screenshots (Japanese):</summary>

![スクリーンショット 2024-10-16 204730](https://github.com/user-attachments/assets/c2f0a337-c024-459c-8286-62470c38d8aa)

![スクリーンショット 2024-10-16 204808](https://github.com/user-attachments/assets/1f26115f-36fc-4d83-9017-44c7b6a71a2f)

![スクリーンショット 2024-10-16 205307](https://github.com/user-attachments/assets/b91fdf07-3c56-49a1-a0f1-384474a4e89a)

</details>

I don't know how to run the English build locally with the current code, so I checked the Chinese build to make sure this change doesn't affect other languages.
<details>
<summary>Screenshots (Chinese):</summary>

![スクリーンショット 2024-10-16 210438](https://github.com/user-attachments/assets/ea29558f-e020-464a-8071-e02180961e8e)

</details>