### PR TITLE
fix: original fCC author casing

### DIFF
--- a/utils/original-post-handler.js
+++ b/utils/original-post-handler.js
@@ -46,7 +46,7 @@ const originalPostHandler = async (originalPostFlag, translatedPostTitle) => {
       let originalAuthorObj = {};
       const originalAuthorRelativePath =
         document.querySelector('.author-card .author-card-name a')?.href ||
-        `/${postPathSegments.slice(0, postPathSegments.length - 1).join('/')}/author/freecodecamp/`;
+        `/${postPathSegments.slice(0, postPathSegments.length - 1).join('/')}/author/freeCodeCamp/`;
       const originalAuthorSlug = originalAuthorRelativePath
         .split('/')
         .filter(Boolean)


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #1043

<!-- Feel free to add any additional description of changes below this line -->
This is a quick fix for cases where the original author is the freeCodeCamp account when using the original author / translator feature.

A more permanent fix will be to normalize all slugs during the build so they're all lowercase, though this may affect SEO negatively unless URLs like https://www.freecodecamp.org/news/author/MiyaLiu/ automatically resolve to https://www.freecodecamp.org/news/author/miyaliu/, or we set up redirects ahead of time.