### PR TITLE
fix: failing english builds

### DIFF
--- a/.github/workflows/deploy-eng.yml
+++ b/.github/workflows/deploy-eng.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
         languages: [english]
         site_tlds: [org]
 

--- a/src/_data/datasource.js
+++ b/src/_data/datasource.js
@@ -24,7 +24,7 @@ const piscinaHashnode = new Piscina({
 module.exports = async () => {
   // Chunk raw Ghost posts and pages and process them in batches
   // with a pool of workers to create posts and pages global data
-  const batchSize = 200;
+  const batchSize = 300;
   const allGhostPosts = await fetchFromGhost('posts');
   const allHashnodePosts = await fetchFromHashnode('posts');
   const allGhostPages = await fetchFromGhost('pages');

--- a/src/_data/datasource.js
+++ b/src/_data/datasource.js
@@ -6,16 +6,19 @@ const fetchFromGhost = require('../../utils/ghost/fetch-from-ghost');
 const fetchFromHashnode = require('../../utils/hashnode/fetch-from-hashnode');
 const { postsPerPage, siteURL } = require('../../config');
 const pingEditorialTeam = require('../../utils/ping-editorial-team');
+const idleTimeoutMS = 3600000; // 1 hour
 
 const getUniqueList = (arr, key) => [
   ...new Map(arr.map(item => [item[key], item])).values()
 ];
 
 const piscinaGhost = new Piscina({
-  filename: resolve(__dirname, '../../utils/ghost/process-batch')
+  filename: resolve(__dirname, '../../utils/ghost/process-batch'),
+  idleTimeout: idleTimeoutMS
 });
 const piscinaHashnode = new Piscina({
-  filename: resolve(__dirname, '../../utils/hashnode/process-batch')
+  filename: resolve(__dirname, '../../utils/hashnode/process-batch'),
+  idleTimeout: idleTimeoutMS
 });
 
 module.exports = async () => {

--- a/utils/ghost/process-batch.js
+++ b/utils/ghost/process-batch.js
@@ -192,6 +192,10 @@ const processBatch = async ({
     })
   );
 
+  console.log(
+    `Finished processing Ghost ${contentType} batch ${currBatchNo} of ${totalBatches}...and using ${process.memoryUsage.rss() / 1024 / 1024} MB of memory`
+  );
+
   return batch;
 };
 

--- a/utils/hashnode/process-batch.js
+++ b/utils/hashnode/process-batch.js
@@ -148,6 +148,10 @@ const processBatch = async ({
     })
   );
 
+  console.log(
+    `Finished processing Hashnode ${contentType} batch ${currBatchNo} of ${totalBatches}...and using ${process.memoryUsage.rss() / 1024 / 1024} MB of memory`
+  );
+
   return batch;
 };
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR sets the timeout for Piscina explicitly to prevent parallel processing of posts / pages from timing out under the hood, and increases batch sizes for fetched posts / pages that are processed.

Edit: Tested and English builds do complete, but can be a bit flaky due to the way we fetch the `trending.json` files from the CDN.

By doing the following things we should fix the flakiness, and help bring more parts of the repo up-to-date:
- Download `trending.json` before the builds similar to the way we do in the main repo
- Require Node v20 in `package.json` and bump the versions in the GHA workflows (after testing with Ghost builds)
- Cleanup Crowdin GHA so we can use Ubuntu 24.04 everywhere (remove Firefox downgrade step)