### PR TITLE
fix: remove probe-image, roll our own solution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "husky": "9.1.7",
         "i18next": "23.16.8",
         "i18next-fs-backend": "2.6.0",
+        "image-size": "2.0.1",
         "jest": "29.7.0",
         "jest-json-schema-extended": "1.0.1",
         "joi": "17.13.3",
@@ -45,7 +46,6 @@
         "npm-run-all2": "7.0.2",
         "piscina": "4.9.2",
         "prettier": "3.4.2",
-        "probe-image-size": "7.2.3",
         "shx": "0.4.0",
         "terser": "5.39.0",
         "typescript": "5.8.2"
@@ -6936,17 +6936,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -6974,6 +6963,19 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.1.tgz",
+      "integrity": "sha512-NI6NK/2zchlZopsQrcVIS7jxA0/rtIy74B+/rx5s7rKQyFebmQjZVhzxXgRZJROk+WhhOq+S6sUaODxp0L5hfg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {
@@ -9848,35 +9850,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/needle": {
-      "version": "2.9.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "bin": {
-        "needle": "bin/needle"
-      },
-      "engines": {
-        "node": ">= 4.4.x"
-      }
-    },
-    "node_modules/needle/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/needle/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "dev": true,
@@ -10748,17 +10721,6 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
-    "node_modules/probe-image-size": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
-      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
-      "dev": true,
-      "dependencies": {
-        "lodash.merge": "^4.6.2",
-        "needle": "^2.5.2",
-        "stream-parser": "~0.3.1"
-      }
-    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -11443,11 +11405,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -11906,22 +11863,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/stream-parser": {
-      "version": "0.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "2"
-      }
-    },
-    "node_modules/stream-parser/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -18163,13 +18104,6 @@
       "integrity": "sha512-3ZlhNoF9yxnM8pa8bWp5120/Ob6t4lVl1l/tbLmkml/ei3ud8IWySCHt2lrY5xWRlSU5D9IV2sm5bEbGuTqwTw==",
       "dev": true
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -18180,6 +18114,12 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true
+    },
+    "image-size": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.1.tgz",
+      "integrity": "sha512-NI6NK/2zchlZopsQrcVIS7jxA0/rtIy74B+/rx5s7rKQyFebmQjZVhzxXgRZJROk+WhhOq+S6sUaODxp0L5hfg==",
       "dev": true
     },
     "import-fresh": {
@@ -20225,28 +20165,6 @@
       "version": "1.4.0",
       "dev": true
     },
-    "needle": {
-      "version": "2.9.1",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.6",
-        "iconv-lite": "^0.4.4",
-        "sax": "^1.2.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.3",
-          "dev": true
-        }
-      }
-    },
     "neo-async": {
       "version": "2.6.2",
       "dev": true
@@ -20843,17 +20761,6 @@
         }
       }
     },
-    "probe-image-size": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
-      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
-      "dev": true,
-      "requires": {
-        "lodash.merge": "^4.6.2",
-        "needle": "^2.5.2",
-        "stream-parser": "~0.3.1"
-      }
-    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -21368,10 +21275,6 @@
       "version": "2.1.2",
       "dev": true
     },
-    "sax": {
-      "version": "1.2.4",
-      "dev": true
-    },
     "saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -21713,22 +21616,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
-    },
-    "stream-parser": {
-      "version": "0.3.1",
-      "dev": true,
-      "requires": {
-        "debug": "2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "husky": "9.1.7",
     "i18next": "23.16.8",
     "i18next-fs-backend": "2.6.0",
+    "image-size": "2.0.1",
     "jest": "29.7.0",
     "jest-json-schema-extended": "1.0.1",
     "joi": "17.13.3",
@@ -102,7 +103,6 @@
     "npm-run-all2": "7.0.2",
     "piscina": "4.9.2",
     "prettier": "3.4.2",
-    "probe-image-size": "7.2.3",
     "shx": "0.4.0",
     "terser": "5.39.0",
     "typescript": "5.8.2"

--- a/utils/get-image-dimensions.js
+++ b/utils/get-image-dimensions.js
@@ -4,26 +4,47 @@ const errorLogger = require('./error-logger');
 const { getCache, setCache } = require('./cache');
 const defaultDimensions = { width: 600, height: 400 };
 
+// Minimum required bytes for common image formats (approximate)
+const imageMinBytes = {
+  jpg: 410,
+  png: 33,
+  gif: 14,
+  webp: 30,
+  bmp: 26,
+  default: 256 // Fallback for other image types
+};
+
 const probeImage = async url => {
   const response = await fetch(url);
   if (!response.ok)
     throw new Error(`Failed to fetch image: ${response.statusText}`);
 
   const chunks = [];
+  let totalLength = 0;
   const reader = response.body;
 
   for await (const chunk of reader) {
     chunks.push(chunk);
+    totalLength += chunk.length;
 
     try {
-      // Try to determine image size with available data
-      const dimensions = imageSize(Buffer.concat(chunks));
+      const buffer = Buffer.concat(chunks, totalLength);
+
+      // Try to detect image format (first few bytes)
+      const { type } = imageSize(buffer);
+      const minBytes = imageMinBytes[type] || imageMinBytes.default;
+
+      // Check buffer length before probing image
+      if (buffer.length < minBytes) continue;
+
+      // Get dimensions
+      const dimensions = imageSize(buffer);
       if (dimensions.width && dimensions.height) {
-        response.body.destroy(); // Stop data stream
+        response.body.destroy(); // Stop downloading
         return dimensions;
       }
     } catch (err) {
-      // Keep reading if more data is needed
+      // Continue reading if more data is needed
     }
   }
 

--- a/utils/get-image-dimensions.js
+++ b/utils/get-image-dimensions.js
@@ -32,8 +32,15 @@ const probeImage = async url => {
 
 const getImageDimensions = async (url, description) => {
   try {
-    if (url.startsWith('data:'))
-      throw new Error('Data URI images are not supported');
+    if (url.startsWith('data:')) {
+      console.warn(`
+        ---------------------------------------------------------------
+        Warning: Skipping data URL for image dimensions in ${description.substring(0, 350)}...
+        ---------------------------------------------------------------
+        `);
+
+      throw new Error('Data URL');
+    }
     let imageDimensions = getCache(url);
     if (imageDimensions) return imageDimensions;
 

--- a/utils/get-image-dimensions.js
+++ b/utils/get-image-dimensions.js
@@ -1,14 +1,43 @@
-const probe = require('probe-image-size');
+const fetch = require('node-fetch');
+const { imageSize } = require('image-size');
 const errorLogger = require('./error-logger');
 const { getCache, setCache } = require('./cache');
 const defaultDimensions = { width: 600, height: 400 };
 
+const probeImage = async url => {
+  const response = await fetch(url);
+  if (!response.ok)
+    throw new Error(`Failed to fetch image: ${response.statusText}`);
+
+  const chunks = [];
+  const reader = response.body;
+
+  for await (const chunk of reader) {
+    chunks.push(chunk);
+
+    try {
+      // Try to determine image size with available data
+      const dimensions = imageSize(Buffer.concat(chunks));
+      if (dimensions.width && dimensions.height) {
+        response.body.destroy(); // Stop data stream
+        return dimensions;
+      }
+    } catch (err) {
+      // Keep reading if more data is needed
+    }
+  }
+
+  throw new Error('Could not determine image size');
+};
+
 const getImageDimensions = async (url, description) => {
   try {
+    if (url.startsWith('data:'))
+      throw new Error('Data URI images are not supported');
     let imageDimensions = getCache(url);
     if (imageDimensions) return imageDimensions;
 
-    const res = await probe(url);
+    const res = await probeImage(url);
     imageDimensions = {
       width: res?.width ? res?.width : defaultDimensions.width,
       height: res?.height ? res?.height : defaultDimensions.height
@@ -17,7 +46,7 @@ const getImageDimensions = async (url, description) => {
 
     return imageDimensions;
   } catch (err) {
-    if (err.statusCode) errorLogger({ type: 'image', name: description }); // Only write HTTP status code errors to log
+    errorLogger({ type: 'image', name: description });
 
     return defaultDimensions;
   }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
It seems like the `probe-image-size` package doesn't play nicely with recent versions of Piscina (used for multithreaded builds) if there are any errors.

For now, I think the best solution is for us to handle image dimension probing on our own. While this may introduce some flakiness with the tests and the final builds, where the width or height for images may return different values in some cases, it doesn't seem like a widespread problem.

If flakiness is an issue going forward, we can take another look at Piscina, and consider replacing it, and / or figure out a way to use the `probe-image-size` package again.