### PR TITLE
fix: move back to probe-image-size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "husky": "9.1.7",
         "i18next": "23.16.8",
         "i18next-fs-backend": "2.6.0",
-        "image-size": "2.0.1",
         "jest": "29.7.0",
         "jest-json-schema-extended": "1.0.1",
         "joi": "17.13.3",
@@ -46,6 +45,7 @@
         "npm-run-all2": "7.0.2",
         "piscina": "4.9.2",
         "prettier": "3.4.2",
+        "probe-image-size": "7.2.3",
         "shx": "0.4.0",
         "terser": "5.39.0",
         "typescript": "5.8.2"
@@ -6936,6 +6936,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -6963,19 +6976,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/image-size": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.1.tgz",
-      "integrity": "sha512-NI6NK/2zchlZopsQrcVIS7jxA0/rtIy74B+/rx5s7rKQyFebmQjZVhzxXgRZJROk+WhhOq+S6sUaODxp0L5hfg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "image-size": "bin/image-size.js"
-      },
-      "engines": {
-        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {
@@ -9850,6 +9850,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "needle": "bin/needle"
+      },
+      "engines": {
+        "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/needle/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/needle/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "dev": true,
@@ -10721,6 +10756,18 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -11405,6 +11452,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -11863,6 +11917,26 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2"
+      }
+    },
+    "node_modules/stream-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -18104,6 +18178,15 @@
       "integrity": "sha512-3ZlhNoF9yxnM8pa8bWp5120/Ob6t4lVl1l/tbLmkml/ei3ud8IWySCHt2lrY5xWRlSU5D9IV2sm5bEbGuTqwTw==",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -18114,12 +18197,6 @@
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "dev": true
-    },
-    "image-size": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.1.tgz",
-      "integrity": "sha512-NI6NK/2zchlZopsQrcVIS7jxA0/rtIy74B+/rx5s7rKQyFebmQjZVhzxXgRZJROk+WhhOq+S6sUaODxp0L5hfg==",
       "dev": true
     },
     "import-fresh": {
@@ -20165,6 +20242,34 @@
       "version": "1.4.0",
       "dev": true
     },
+    "needle": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
+      "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        }
+      }
+    },
     "neo-async": {
       "version": "2.6.2",
       "dev": true
@@ -20761,6 +20866,17 @@
         }
       }
     },
+    "probe-image-size": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
+      "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
+      "dev": true,
+      "requires": {
+        "lodash.merge": "^4.6.2",
+        "needle": "^2.5.2",
+        "stream-parser": "~0.3.1"
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -21275,6 +21391,12 @@
       "version": "2.1.2",
       "dev": true
     },
+    "sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
+      "dev": true
+    },
     "saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -21616,6 +21738,26 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
+    },
+    "stream-parser": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
+      "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
+      "dev": true,
+      "requires": {
+        "debug": "2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "husky": "9.1.7",
     "i18next": "23.16.8",
     "i18next-fs-backend": "2.6.0",
-    "image-size": "2.0.1",
     "jest": "29.7.0",
     "jest-json-schema-extended": "1.0.1",
     "joi": "17.13.3",
@@ -103,6 +102,7 @@
     "npm-run-all2": "7.0.2",
     "piscina": "4.9.2",
     "prettier": "3.4.2",
+    "probe-image-size": "7.2.3",
     "shx": "0.4.0",
     "terser": "5.39.0",
     "typescript": "5.8.2"

--- a/src/_data/datasource.js
+++ b/src/_data/datasource.js
@@ -6,25 +6,22 @@ const fetchFromGhost = require('../../utils/ghost/fetch-from-ghost');
 const fetchFromHashnode = require('../../utils/hashnode/fetch-from-hashnode');
 const { postsPerPage, siteURL } = require('../../config');
 const pingEditorialTeam = require('../../utils/ping-editorial-team');
-const idleTimeoutMS = 3600000; // 1 hour
 
 const getUniqueList = (arr, key) => [
   ...new Map(arr.map(item => [item[key], item])).values()
 ];
 
 const piscinaGhost = new Piscina({
-  filename: resolve(__dirname, '../../utils/ghost/process-batch'),
-  idleTimeout: idleTimeoutMS
+  filename: resolve(__dirname, '../../utils/ghost/process-batch')
 });
 const piscinaHashnode = new Piscina({
-  filename: resolve(__dirname, '../../utils/hashnode/process-batch'),
-  idleTimeout: idleTimeoutMS
+  filename: resolve(__dirname, '../../utils/hashnode/process-batch')
 });
 
 module.exports = async () => {
   // Chunk raw Ghost posts and pages and process them in batches
   // with a pool of workers to create posts and pages global data
-  const batchSize = 300;
+  const batchSize = 200;
   const allGhostPosts = await fetchFromGhost('posts');
   const allHashnodePosts = await fetchFromHashnode('posts');
   const allGhostPages = await fetchFromGhost('pages');

--- a/utils/get-image-dimensions.js
+++ b/utils/get-image-dimensions.js
@@ -31,9 +31,9 @@ const getImageDimensions = async (url, description) => {
     setCache(url, imageDimensions);
   } catch (err) {
     errorLogger({ type: 'image', name: description });
-  } finally {
-    return imageDimensions;
   }
+
+  return imageDimensions;
 };
 
 module.exports = getImageDimensions;

--- a/utils/get-image-dimensions.js
+++ b/utils/get-image-dimensions.js
@@ -1,9 +1,10 @@
 const probe = require('probe-image-size');
 const errorLogger = require('./error-logger');
 const { getCache, setCache } = require('./cache');
-const defaultDimensions = { width: 600, height: 400 };
 
 const getImageDimensions = async (url, description) => {
+  let imageDimensions = { width: 600, height: 400 };
+
   try {
     if (url.startsWith('data:')) {
       console.warn(`
@@ -12,71 +13,27 @@ const getImageDimensions = async (url, description) => {
         ---------------------------------------------------------------
         `);
 
-      // throw new Error('Data URL');
-      return defaultDimensions;
+      throw new Error('Data URL');
     }
-    let imageDimensions = getCache(url);
-    if (imageDimensions) return imageDimensions;
+    const cachedDimensions = getCache(url);
+    if (cachedDimensions) imageDimensions = cachedDimensions;
 
-    const res = await probe(url, {
-      open_timeout: 5000,
-      response_timeout: 3000,
-      read_timeout: 3000
-      // rejectUnauthorized: true
-    });
-    // const res = await probe(url);
+    const fetchedImageDimensions = await probe(url);
     imageDimensions = {
-      width: res?.width ? res?.width : defaultDimensions.width,
-      height: res?.height ? res?.height : defaultDimensions.height
+      width: fetchedImageDimensions?.width
+        ? fetchedImageDimensions?.width
+        : imageDimensions.width,
+      height: fetchedImageDimensions?.height
+        ? fetchedImageDimensions?.height
+        : imageDimensions.height
     };
-    setCache(url, imageDimensions);
 
-    return imageDimensions;
+    setCache(url, imageDimensions);
   } catch (err) {
     errorLogger({ type: 'image', name: description });
-
-    return defaultDimensions;
+  } finally {
+    return imageDimensions;
   }
 };
-
-// const getImageDimensions = async (url, description) => {
-//   // try {
-//   //   if (url.startsWith('data:')) {
-//   //     console.warn(`
-//   //       ---------------------------------------------------------------
-//   //       Warning: Skipping data URL for image dimensions in ${description.substring(0, 350)}...
-//   //       ---------------------------------------------------------------
-//   //       `);
-
-//   //     return defaultDimensions;
-//   //   }
-//   //   const res = await probe(url);
-
-//   //   const imageDimensions = {
-//   //     width: res?.width ? res?.width : defaultDimensions.width,
-//   //     height: res?.height ? res?.height : defaultDimensions.height
-//   //   };
-
-//   //   return imageDimensions;
-//   // } catch (err) {
-//   //   errorLogger({ type: 'image', name: description });
-
-//   //   return defaultDimensions;
-//   // }
-
-//   try {
-//     const res = await probe(url);
-//     const imageDimensions = {
-//       width: res?.width ? res?.width : defaultDimensions.width,
-//       height: res?.height ? res?.height : defaultDimensions.height
-//     };
-
-//     return imageDimensions;
-//   } catch (err) {
-//     errorLogger({ type: 'image', name: description });
-
-//     return defaultDimensions;
-//   }
-// };
 
 module.exports = getImageDimensions;

--- a/utils/get-image-dimensions.js
+++ b/utils/get-image-dimensions.js
@@ -18,7 +18,14 @@ const getImageDimensions = async (url, description) => {
     const cachedDimensions = getCache(url);
     if (cachedDimensions) imageDimensions = cachedDimensions;
 
-    const fetchedImageDimensions = await probe(url);
+    const fetchedImageDimensions = await probe(url, {
+      open_timeout: 5000,
+      response_timeout: 5000,
+      read_timeout: 5000,
+      // Don't follow redirects, which can
+      // cause some localized builds to hang
+      follow_max: 0
+    });
     imageDimensions = {
       width: fetchedImageDimensions?.width
         ? fetchedImageDimensions?.width


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
`probe-image-size` is so much faster than any other solution I've been able to find, and should be ESM compatible in the future if we move in that direction, so it's best to go back to that.

After a lot of digging, it seems like the issue is that the network requests it's making under the hood follow redirects, which don't result in the final image. Might have something to do with the redirect from https://www.freecodecamp.org/news/content/images/2023/08/Learn-Python-with-Code-Examples-Handbook-Cover--2-.png --> https://cdn-media-0.freecodecamp.org/2023/08/Learn-Python-with-Code-Examples-Handbook-Cover--2-.png, and Cloudflare not allowing hotlinking?

Either way, the main fix is to go down from the default max redirects of 10 to 0. This probably means that more images won't have proper dimensions, but that should be fixed once we move to a new platform and move all images to a CDN.