### PR TITLE
fix: generate serve config script for final build step

### DIFF
--- a/config/i18n/generate-serve-config.js
+++ b/config/i18n/generate-serve-config.js
@@ -1,10 +1,11 @@
 import gracefulFS from 'graceful-fs';
 import { join } from 'path';
 
-import { locales } from '../index.js';
+import { config } from '../../config/index.js';
 import { loadJSON } from '../../utils/load-json.js';
-import source from '../serve.json';
+import source from '../serve.json' with { type: 'json' };
 
+const { locales } = config;
 const { writeFileSync, mkdirSync } = gracefulFS;
 
 locales.push('dothraki');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This should fix the `generate-serve-config.js` script, which is called during a final build step, and was overlooked in https://github.com/freeCodeCamp/news/pull/1168.