### PR TITLE
chore: add redirect for author page

### DIFF
--- a/config/i18n/locales/english/redirects.json
+++ b/config/i18n/locales/english/redirects.json
@@ -20,6 +20,11 @@
     "destination": "/news/about"
   },
   {
+    "source": "/author/Ophelia",
+    "destination": "/news/author/CodeHemaa",
+    "type": 302
+  },
+  {
     "source": "/everything-you-need-to-know-about-ng-template-ng-content-ng-container-and-ngtemplateoutlet-4b7b51223691",
     "destination": "/news/angular-vs-angularjs",
     "type": 302


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
One of our authors asked us to set up this redirect for them. They've sent out job applications with the link to their old Ghost author page, https://www.freecodecamp.org/news/author/Ophelia/, which now leads to a 404.

This change should redirect those requests to the new author page with their HN username, https://www.freecodecamp.org/news/author/CodeHemaa/.