### PR TITLE
fix: localized search results and search page

### DIFF
--- a/cypress/e2e/english/search-results/search-results.cy.ts
+++ b/cypress/e2e/english/search-results/search-results.cy.ts
@@ -22,49 +22,49 @@ describe('Search results', () => {
     cy.get('footer').should('be.visible');
   });
 
-  it("should show the author's profile image", () => {
-    cy.get(selectors.postCard)
-      .contains(
-        'freeCodeCamp Just Got a Million Dollar Donation from an Alum to Build a Carbon-Neutral Web3 Curriculum'
-      )
-      .parentsUntil('article')
-      .find(selectors.authorProfileImage)
-      .then($el => expect($el[0].tagName.toLowerCase()).to.equal('img'));
-  });
+  // it("should show the author's profile image", () => {
+  //   cy.get(selectors.postCard)
+  //     .contains(
+  //       'freeCodeCamp Just Got a Million Dollar Donation from an Alum to Build a Carbon-Neutral Web3 Curriculum'
+  //     )
+  //     .parentsUntil('article')
+  //     .find(selectors.authorProfileImage)
+  //     .then($el => expect($el[0].tagName.toLowerCase()).to.equal('img'));
+  // });
 
-  it("the author profile image should contain an `alt` attribute with the author's name", () => {
-    cy.get(selectors.postCard)
-      .contains(
-        'freeCodeCamp Just Got a Million Dollar Donation from an Alum to Build a Carbon-Neutral Web3 Curriculum'
-      )
-      .parentsUntil('article')
-      .find<HTMLImageElement>(selectors.authorProfileImage)
-      .then($el => expect($el[0].alt).to.equal('Quincy Larson'));
-  });
+  // it("the author profile image should contain an `alt` attribute with the author's name", () => {
+  //   cy.get(selectors.postCard)
+  //     .contains(
+  //       'freeCodeCamp Just Got a Million Dollar Donation from an Alum to Build a Carbon-Neutral Web3 Curriculum'
+  //     )
+  //     .parentsUntil('article')
+  //     .find<HTMLImageElement>(selectors.authorProfileImage)
+  //     .then($el => expect($el[0].alt).to.equal('Quincy Larson'));
+  // });
 
-  it('post cards written by an author with no profile image should show the author SVG', () => {
-    cy.get(selectors.postCard)
-      .contains('No Author Profile Pic')
-      .parentsUntil('article')
-      .find(selectors.avatar)
-      .then($el => expect($el[0].tagName.toLowerCase()).to.equal('svg'));
-  });
+  // it('post cards written by an author with no profile image should show the author SVG', () => {
+  //   cy.get(selectors.postCard)
+  //     .contains('No Author Profile Pic')
+  //     .parentsUntil('article')
+  //     .find(selectors.avatar)
+  //     .then($el => expect($el[0].tagName.toLowerCase()).to.equal('svg'));
+  // });
 
-  it("the avatar SVG should contain a `title` element with the author's name", () => {
-    cy.get(selectors.postCard)
-      .contains('No Author Profile Pic')
-      .parentsUntil('article')
-      .find(selectors.avatar)
-      .contains('title', 'Mrugesh Mohapatra');
-  });
+  // it("the avatar SVG should contain a `title` element with the author's name", () => {
+  //   cy.get(selectors.postCard)
+  //     .contains('No Author Profile Pic')
+  //     .parentsUntil('article')
+  //     .find(selectors.avatar)
+  //     .contains('title', 'Mrugesh Mohapatra');
+  // });
 
-  it("posts written by 'freeCodeCamp.org' should not show the `author-list`, which contain's the author's name and profile image", () => {
-    cy.get(selectors.postCard)
-      .contains('Common Technical Support Questions – freeCodeCamp FAQ')
-      .parentsUntil('article')
-      .find(selectors.authorList)
-      .should('not.exist');
-  });
+  // it("posts written by 'freeCodeCamp.org' should not show the `author-list`, which contain's the author's name and profile image", () => {
+  //   cy.get(selectors.postCard)
+  //     .contains('Common Technical Support Questions – freeCodeCamp FAQ')
+  //     .parentsUntil('article')
+  //     .find(selectors.authorList)
+  //     .should('not.exist');
+  // });
 
   // To do: Finalize search schema and add tests for the original post / translator feature
 });

--- a/cypress/e2e/english/search-results/search-results.cy.ts
+++ b/cypress/e2e/english/search-results/search-results.cy.ts
@@ -22,49 +22,49 @@ describe('Search results', () => {
     cy.get('footer').should('be.visible');
   });
 
-  // it("should show the author's profile image", () => {
-  //   cy.get(selectors.postCard)
-  //     .contains(
-  //       'freeCodeCamp Just Got a Million Dollar Donation from an Alum to Build a Carbon-Neutral Web3 Curriculum'
-  //     )
-  //     .parentsUntil('article')
-  //     .find(selectors.authorProfileImage)
-  //     .then($el => expect($el[0].tagName.toLowerCase()).to.equal('img'));
-  // });
+  it("should show the author's profile image", () => {
+    cy.get(selectors.postCard)
+      .contains(
+        'freeCodeCamp Just Got a Million Dollar Donation from an Alum to Build a Carbon-Neutral Web3 Curriculum'
+      )
+      .parentsUntil('article')
+      .find(selectors.authorProfileImage)
+      .then($el => expect($el[0].tagName.toLowerCase()).to.equal('img'));
+  });
 
-  // it("the author profile image should contain an `alt` attribute with the author's name", () => {
-  //   cy.get(selectors.postCard)
-  //     .contains(
-  //       'freeCodeCamp Just Got a Million Dollar Donation from an Alum to Build a Carbon-Neutral Web3 Curriculum'
-  //     )
-  //     .parentsUntil('article')
-  //     .find<HTMLImageElement>(selectors.authorProfileImage)
-  //     .then($el => expect($el[0].alt).to.equal('Quincy Larson'));
-  // });
+  it("the author profile image should contain an `alt` attribute with the author's name", () => {
+    cy.get(selectors.postCard)
+      .contains(
+        'freeCodeCamp Just Got a Million Dollar Donation from an Alum to Build a Carbon-Neutral Web3 Curriculum'
+      )
+      .parentsUntil('article')
+      .find<HTMLImageElement>(selectors.authorProfileImage)
+      .then($el => expect($el[0].alt).to.equal('Quincy Larson'));
+  });
 
-  // it('post cards written by an author with no profile image should show the author SVG', () => {
-  //   cy.get(selectors.postCard)
-  //     .contains('No Author Profile Pic')
-  //     .parentsUntil('article')
-  //     .find(selectors.avatar)
-  //     .then($el => expect($el[0].tagName.toLowerCase()).to.equal('svg'));
-  // });
+  it('post cards written by an author with no profile image should show the author SVG', () => {
+    cy.get(selectors.postCard)
+      .contains('No Author Profile Pic')
+      .parentsUntil('article')
+      .find(selectors.avatar)
+      .then($el => expect($el[0].tagName.toLowerCase()).to.equal('svg'));
+  });
 
-  // it("the avatar SVG should contain a `title` element with the author's name", () => {
-  //   cy.get(selectors.postCard)
-  //     .contains('No Author Profile Pic')
-  //     .parentsUntil('article')
-  //     .find(selectors.avatar)
-  //     .contains('title', 'Mrugesh Mohapatra');
-  // });
+  it("the avatar SVG should contain a `title` element with the author's name", () => {
+    cy.get(selectors.postCard)
+      .contains('No Author Profile Pic')
+      .parentsUntil('article')
+      .find(selectors.avatar)
+      .contains('title', 'Mrugesh Mohapatra');
+  });
 
-  // it("posts written by 'freeCodeCamp.org' should not show the `author-list`, which contain's the author's name and profile image", () => {
-  //   cy.get(selectors.postCard)
-  //     .contains('Common Technical Support Questions – freeCodeCamp FAQ')
-  //     .parentsUntil('article')
-  //     .find(selectors.authorList)
-  //     .should('not.exist');
-  // });
+  it("posts written by 'freeCodeCamp.org' should not show the `author-list`, which contain's the author's name and profile image", () => {
+    cy.get(selectors.postCard)
+      .contains('Common Technical Support Questions – freeCodeCamp FAQ')
+      .parentsUntil('article')
+      .find(selectors.authorList)
+      .should('not.exist');
+  });
 
   // To do: Finalize search schema and add tests for the original post / translator feature
 });

--- a/src/_includes/assets/js/search-bar.js
+++ b/src/_includes/assets/js/search-bar.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', async () => {
                 searchClient,
                 queries: [
                   {
-                    indexName: 'news',
+                    indexName: '{{ secrets.algoliaIndex }}',
                     params: {
                       query,
                       hitsPerPage: hitsToRender

--- a/src/_includes/assets/js/search-results.js
+++ b/src/_includes/assets/js/search-results.js
@@ -1,4 +1,10 @@
 document.addEventListener('DOMContentLoaded', async () => {
+  const { liteClient } = window['algoliasearch/lite'];
+
+  const searchClient = liteClient(
+    '{{ secrets.algoliaAppId }}',
+    '{{ secrets.algoliaAPIKey }}'
+  );
   const urlParams = new URLSearchParams(window.location.search);
   const queryStr = urlParams.get('query') || '';
   const postFeed = document.querySelector('.post-feed');
@@ -18,16 +24,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         return mockHits;
       }
 
-      // eslint-disable-next-line no-undef
-      return index
-        .search({
+      const response = await searchClient.search([
+        {
+          indexName: '{{ secrets.algoliaIndex }}',
           query: queryStr,
-          hitsPerPage: postsPerPage,
-          page: pageNo
-        })
-        .then(({ hits } = {}) => {
-          return hits;
-        });
+          params: {
+            hitsPerPage: postsPerPage,
+            page: pageNo
+          }
+        }
+      ]);
+
+      return response?.results[0]?.hits;
     } catch (err) {
       console.log(err);
       err.debugData ? console.log(err.debugData) : '';


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/news/pull/1341

<!-- Feel free to add any additional description of changes below this line -->
This PR fixes a couple of issues from major search overhaul in https://github.com/freeCodeCamp/news/pull/1341:

1. Searching other News indicies is fixed now that we're setting the index dynamically during the build with `{{ secrets.algoliaIndex }}`
2. The search results page has been updated for Algolia v5 as well, which I forgot to check for in the last PR