### PR TITLE
fix: hashnode embed handling

### DIFF
--- a/utils/modify-html-content.js
+++ b/utils/modify-html-content.js
@@ -19,12 +19,21 @@ export const modifyHTMLContent = async ({ postContent, postTitle, source }) => {
   if (source === 'Hashnode' && hashnodeEmbedAnchorEls.length) {
     await Promise.all(
       hashnodeEmbedAnchorEls.map(async anchorEl => {
-        const embedWrapper = anchorEl.parentElement;
+        const embedWrapper = anchorEl?.parentElement;
         const embedURL = anchorEl.href;
         const embedMarkup = await generateHashnodeEmbedMarkup(embedURL);
 
+        // Leave existing wrappers intact for existing embeds,
+        // but for new embeds wrapped in a simple p tag, replace the p tag
+        // with the iframe embed markup to wrap in a div.embed-wrapper later
         if (embedMarkup) {
-          embedWrapper.innerHTML = embedMarkup;
+          if (embedWrapper?.classList.contains('embed-wrapper')) {
+            embedWrapper.innerHTML = embedMarkup;
+          } else {
+            embedWrapper.replaceWith(
+              ...new JSDOM(embedMarkup).window.document.body.childNodes
+            );
+          }
         }
       })
     );
@@ -56,7 +65,8 @@ export const modifyHTMLContent = async ({ postContent, postTitle, source }) => {
     iframes.map(async iframe => {
       if (!iframe.title) iframe.setAttribute('title', translate('embed-title'));
       // For iframes on Hashnode that were copy and pasted into an HTML block,
-      // wrap them in a div similar to how Hashnode does for links in embed blocks
+      // or iframes we generate for supported embeds, wrap them in a div similar
+      // to how Hashnode does for links in embed blocks
       if (
         source === 'Hashnode' &&
         !['embed-wrapper', 'giphy-wrapper'].some(className =>
@@ -73,6 +83,8 @@ export const modifyHTMLContent = async ({ postContent, postTitle, source }) => {
       iframe.setAttribute('loading', 'lazy');
     })
   );
+
+  console.log(document.body.innerHTML);
 
   // The jsdom parser wraps the incomplete HTML from the Ghost
   // API with HTML, head, and body elements, so return whatever

--- a/utils/modify-html-content.js
+++ b/utils/modify-html-content.js
@@ -14,21 +14,21 @@ export const modifyHTMLContent = async ({ postContent, postTitle, source }) => {
   const dom = new JSDOM(postContent);
   const window = dom.window;
   const document = window.document;
-  const hashnodeEmbedAnchorEls = [
-    ...document.querySelectorAll('div.embed-wrapper a.embed-card')
-  ];
+  const hashnodeEmbedAnchorEls = [...document.querySelectorAll('a.embed-card')];
 
-  await Promise.all(
-    hashnodeEmbedAnchorEls.map(async anchorEl => {
-      const embedWrapper = anchorEl.parentElement;
-      const embedURL = anchorEl.href;
-      const embedMarkup = await generateHashnodeEmbedMarkup(embedURL);
+  if (source === 'Hashnode' && hashnodeEmbedAnchorEls.length) {
+    await Promise.all(
+      hashnodeEmbedAnchorEls.map(async anchorEl => {
+        const embedWrapper = anchorEl.parentElement;
+        const embedURL = anchorEl.href;
+        const embedMarkup = await generateHashnodeEmbedMarkup(embedURL);
 
-      if (embedMarkup) {
-        embedWrapper.innerHTML = embedMarkup;
-      }
-    })
-  );
+        if (embedMarkup) {
+          embedWrapper.innerHTML = embedMarkup;
+        }
+      })
+    );
+  }
 
   const embeds = [...document.getElementsByTagName('embed')];
   const images = [...document.getElementsByTagName('img')];

--- a/utils/modify-html-content.test.js
+++ b/utils/modify-html-content.test.js
@@ -15,7 +15,9 @@ const mockHashnodeEmbeds = {
   githubGist:
     '<div class="gist-block embed-wrapper" data-gist-show-loading="false" data-id="539dbbd01ebfd36fd8a671124d290f5a"><div class="embed-loading"><div class="loadingRow"></div><div class="loadingRow"></div></div><a href="https://gist.github.com/scissorsneedfoodtoo/539dbbd01ebfd36fd8a671124d290f5a" class="embed-card">https://gist.github.com/scissorsneedfoodtoo/539dbbd01ebfd36fd8a671124d290f5a</a></div>',
   iframeInHTMLBlock:
-    '<iframe width="560" height="315" src="https://www.youtube.com/embed/N1pYdEAU9mk?si=BapivyRfMfD99MTc"></iframe>'
+    '<iframe width="560" height="315" src="https://www.youtube.com/embed/N1pYdEAU9mk?si=BapivyRfMfD99MTc"></iframe>',
+  embedNoWrapper:
+    '<a class="embed-card" href="https://youtu.be/0WjfKQdfeMU">https://youtu.be/0WjfKQdfeMU</a>'
 };
 
 describe('modifyHTMLContent', () => {
@@ -172,6 +174,38 @@ describe('modifyHTMLContent', () => {
     expect(iframeEl.width).toBe('560');
     expect(iframeEl.height).toBe('315');
     expect(iframeEl.title).toBe(translate('embed-title'));
+
+    // Check if the iframeEl is wrapped in a div with the expected class
+    expect(iframeEl.parentElement.tagName).toBe('DIV');
+    expect(iframeEl.parentElement.classList).toContain('embed-wrapper');
+  });
+
+  it('embeds with no wrapper should return the expected modified HTML', async () => {
+    const modifiedHTML = await modifyHTMLContent({
+      postContent: mockHashnodeEmbeds.embedNoWrapper,
+      postTitle: 'Test Post',
+      source: 'Hashnode'
+    });
+    const dom = new JSDOM(modifiedHTML);
+    const document = dom.window.document;
+    const iframeEl = document.querySelector('iframe');
+
+    expect(iframeEl).toBeTruthy();
+    expect(iframeEl.src).toBe('https://www.youtube.com/embed/0WjfKQdfeMU');
+    expect(iframeEl.width).toBe('560');
+    expect(iframeEl.height).toBe('315');
+    expect(iframeEl.title).toBe('YouTube video player');
+    expect(iframeEl.getAttribute('style')).toBe(
+      'aspect-ratio: 16 / 9; width: 100%; height: auto;'
+    );
+    expect(iframeEl.getAttribute('allow')).toBe(
+      'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
+    );
+    expect(iframeEl.getAttribute('referrerpolicy')).toBe(
+      'strict-origin-when-cross-origin'
+    );
+    expect(iframeEl.getAttribute('allowfullscreen')).toBe('');
+    expect(iframeEl.getAttribute('loading')).toBe('lazy');
 
     // Check if the iframeEl is wrapped in a div with the expected class
     expect(iframeEl.parentElement.tagName).toBe('DIV');

--- a/utils/modify-html-content.test.js
+++ b/utils/modify-html-content.test.js
@@ -17,7 +17,7 @@ const mockHashnodeEmbeds = {
   iframeInHTMLBlock:
     '<iframe width="560" height="315" src="https://www.youtube.com/embed/N1pYdEAU9mk?si=BapivyRfMfD99MTc"></iframe>',
   embedNoWrapper:
-    '<a class="embed-card" href="https://youtu.be/0WjfKQdfeMU">https://youtu.be/0WjfKQdfeMU</a>'
+    '<p><a class="embed-card" href="https://youtu.be/0WjfKQdfeMU">https://youtu.be/0WjfKQdfeMU</a></p>'
 };
 
 describe('modifyHTMLContent', () => {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Old HN embed cards had the following structure:

```html
<div class="embed-wrapper">
  <div class="embed-loading">
    <div class="loadingRow"></div>
    <div class="loadingRow"></div>
  </div>
  <a class="embed-card" href="https://www.youtube.com/watch?v=KZe0C0Qq4p0">
    https://www.youtube.com/watch?v=KZe0C0Qq4p0
  </a>
</div>
```

But current ones are simpler:

```html
<p>
  <a class="embed-card" href="https://youtu.be/0WjfKQdfeMU">
    https://youtu.be/0WjfKQdfeMU
  </a>
</p>
```

This PR makes the selector we use in the `modifyHTMLContent` function more generic when parsing HN sourced HTML for embed cards so we turn them into `iframe` elements, wrap them in divs, and let our styling kick in during builds.

This has mostly been tested with YouTube embeds, which are the most common. It'll take some time to see what HN returns for other embed types, so I'll follow up with another PR to fix those if necessary.