### PR TITLE
fix: ignore pnpm lock file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 # Comment out the line below to run Prettier against the files in the final build
 dist/
-package-lock.json
+pnpm-lock.yaml


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Some recent PRs are failing because the lint script goes through the `pnpm-lock.yaml` file and throws a warning. This should prevent this file from being linted or formatted in the future.