### PR TITLE
fix: disable pnpm side effects cache in favor of cypress caching

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+side-effects-cache=false


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Cypress tests for some recent PRs have been failing with this message: https://github.com/freeCodeCamp/news/actions/runs/22934823827/job/66563793202?pr=1360#step:7:44

In the [pnpm configuration](https://docs.cypress.io/app/get-started/install-cypress#pnpm-configuration) section of their docs, they recommend disabling pnpm's side effects caching, which can interfere with Cypress's postinstall script during setup.

This should hopefully fix the issues with Cypress not running properly during automated checks.