### PR TITLE
fix: add missing ids to headings for toc

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,9 @@
     "piscina": "5.1.4",
     "prettier": "3.8.1",
     "probe-image-size": "7.2.3",
+    "sanitize-html": "2.17.2",
     "shx": "0.4.0",
+    "slug": "11.0.1",
     "terser": "5.46.0",
     "typescript": "5.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,9 +125,15 @@ importers:
       probe-image-size:
         specifier: 7.2.3
         version: 7.2.3
+      sanitize-html:
+        specifier: 2.17.2
+        version: 2.17.2
       shx:
         specifier: 0.4.0
         version: 0.4.0
+      slug:
+        specifier: 11.0.1
+        version: 11.0.1
       terser:
         specifier: 5.46.0
         version: 5.46.0
@@ -1515,6 +1521,9 @@ packages:
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
@@ -1522,8 +1531,15 @@ packages:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
 
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv@17.3.1:
     resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
@@ -1585,6 +1601,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -2029,6 +2049,9 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   htmlparser2@7.2.0:
     resolution: {integrity: sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==}
 
@@ -2199,6 +2222,10 @@ packages:
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2716,6 +2743,11 @@ packages:
   nan@2.25.0:
     resolution: {integrity: sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2957,6 +2989,10 @@ packages:
   please-upgrade-node@3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
 
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   posthtml-match-helper@2.0.3:
     resolution: {integrity: sha512-p9oJgTdMF2dyd7WE54QI1LvpBIkNkbSiiECKezNnDVYhGhD1AaOnAkw0Uh0y5TW+OHO8iBdSqnd8Wkpb6iUqmw==}
     engines: {node: '>=18'}
@@ -3122,6 +3158,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sanitize-html@2.17.2:
+    resolution: {integrity: sha512-EnffJUl46VE9uvZ0XeWzObHLurClLlT12gsOk1cHyP2Ol1P0BnBnsXmShlBmWVJM+dKieQI68R0tsPY5m/B+Jg==}
+
   sax@1.5.0:
     resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
     engines: {node: '>=11.0.0'}
@@ -3229,6 +3268,10 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
+  slug@11.0.1:
+    resolution: {integrity: sha512-VrM060OM/E7rdLQSnp6JHrzFfJFmqQBp0+TMhZStnEB8PfNliaZ9UWYjTHGHLUFVJorZ8TjVd/aKvIxHWU2O7g==}
+    hasBin: true
+
   slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
     engines: {node: '>=8.0.0'}
@@ -3244,6 +3287,10 @@ packages:
   socks@2.8.7:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
@@ -5236,9 +5283,19 @@ snapshots:
       domhandler: 4.3.1
       entities: 2.2.0
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
   domelementtype@2.3.0: {}
 
   domhandler@4.3.1:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
 
@@ -5247,6 +5304,12 @@ snapshots:
       dom-serializer: 1.4.1
       domelementtype: 2.3.0
       domhandler: 4.3.1
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv@17.3.1: {}
 
@@ -5298,6 +5361,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -5771,6 +5836,13 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   htmlparser2@7.2.0:
     dependencies:
       domelementtype: 2.3.0
@@ -5922,6 +5994,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-path-inside@3.0.3: {}
+
+  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -6656,6 +6730,8 @@ snapshots:
 
   nan@2.25.0: {}
 
+  nanoid@3.3.11: {}
+
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -6874,6 +6950,12 @@ snapshots:
     dependencies:
       semver-compare: 1.0.0
 
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   posthtml-match-helper@2.0.3(posthtml@0.16.7):
     dependencies:
       posthtml: 0.16.7
@@ -7019,6 +7101,15 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sanitize-html@2.17.2:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      parse-srcset: 1.0.2
+      postcss: 8.5.8
+
   sax@1.5.0: {}
 
   saxes@6.0.0:
@@ -7138,6 +7229,8 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  slug@11.0.1: {}
+
   slugify@1.6.6: {}
 
   smart-buffer@4.2.0: {}
@@ -7154,6 +7247,8 @@ snapshots:
     dependencies:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
     dependencies:

--- a/utils/modify-html-content.js
+++ b/utils/modify-html-content.js
@@ -3,7 +3,8 @@ import jsdom from 'jsdom';
 import { translate } from './translate.js';
 import {
   generateHashnodeEmbedMarkup,
-  setDefaultAlt
+  setDefaultAlt,
+  HeadingSlugger
 } from './modify-html-helpers.js';
 import { getImageDimensions } from './get-image-dimensions.js';
 import { fitVids } from './fitvids.js';
@@ -16,27 +17,42 @@ export const modifyHTMLContent = async ({ postContent, postTitle, source }) => {
   const document = window.document;
   const hashnodeEmbedAnchorEls = [...document.querySelectorAll('a.embed-card')];
 
-  if (source === 'Hashnode' && hashnodeEmbedAnchorEls.length) {
-    await Promise.all(
-      hashnodeEmbedAnchorEls.map(async anchorEl => {
-        const embedWrapper = anchorEl?.parentElement;
-        const embedURL = anchorEl.href;
-        const embedMarkup = await generateHashnodeEmbedMarkup(embedURL);
+  if (source === 'Hashnode') {
+    if (hashnodeEmbedAnchorEls.length) {
+      await Promise.all(
+        hashnodeEmbedAnchorEls.map(async anchorEl => {
+          const embedWrapper = anchorEl?.parentElement;
+          const embedURL = anchorEl.href;
+          const embedMarkup = await generateHashnodeEmbedMarkup(embedURL);
 
-        // Leave existing wrappers intact for existing embeds,
-        // but for new embeds wrapped in a simple p tag, replace the p tag
-        // with the iframe embed markup to wrap in a div.embed-wrapper later
-        if (embedMarkup) {
-          if (embedWrapper?.classList.contains('embed-wrapper')) {
-            embedWrapper.innerHTML = embedMarkup;
-          } else {
-            embedWrapper.replaceWith(
-              ...new JSDOM(embedMarkup).window.document.body.childNodes
-            );
+          // Leave existing wrappers intact for existing embeds,
+          // but for new embeds wrapped in a simple p tag, replace the p tag
+          // with the iframe embed markup to wrap in a div.embed-wrapper later
+          if (embedMarkup) {
+            if (embedWrapper?.classList.contains('embed-wrapper')) {
+              embedWrapper.innerHTML = embedMarkup;
+            } else {
+              embedWrapper.replaceWith(
+                ...new JSDOM(embedMarkup).window.document.body.childNodes
+              );
+            }
           }
-        }
-      })
-    );
+        })
+      );
+    }
+
+    // Generate ids for headings that don't have them for anchor linking
+    const slugger = new HeadingSlugger();
+    ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].forEach(tag => {
+      const headings = document.querySelectorAll(tag);
+      [...headings]
+        .filter(heading => !heading.hasAttribute('id'))
+        .forEach(heading => {
+          const textContent = heading.textContent || '';
+          const slug = slugger.getSlug(textContent);
+          heading.setAttribute('id', `heading-${slug}`);
+        });
+    });
   }
 
   const embeds = [...document.getElementsByTagName('embed')];

--- a/utils/modify-html-content.test.js
+++ b/utils/modify-html-content.test.js
@@ -20,195 +20,248 @@ const mockHashnodeEmbeds = {
     '<p><a class="embed-card" href="https://youtu.be/0WjfKQdfeMU">https://youtu.be/0WjfKQdfeMU</a></p>'
 };
 
+const mockHeadings = {
+  withNoId: '<h2>The Typical Workflow</h2>',
+  withExistingId: '<h2 id="my-personal-workflow">My Personal Workflow</h2>',
+  withNestedElements:
+    '<h2><strong>Bold and <em>Emphasized</em> Text</strong></h2>'
+};
+
 describe('modifyHTMLContent', () => {
-  it('common embeds like YouTube should return the expected modified HTML', async () => {
-    const modifiedHTML = await modifyHTMLContent({
-      postContent: mockHashnodeEmbeds.youtube,
-      postTitle: 'Test Post',
-      source: 'Hashnode'
+  describe('Hashnode embeds', () => {
+    it('common embeds like YouTube should return the expected modified HTML', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHashnodeEmbeds.youtube,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const iframeEl = document.querySelector('iframe');
+
+      expect(iframeEl).toBeTruthy();
+      expect(iframeEl.src).toBe('https://www.youtube.com/embed/KZe0C0Qq4p0');
+      expect(iframeEl.width).toBe('560');
+      expect(iframeEl.height).toBe('315');
+      expect(iframeEl.title).toBe('YouTube video player');
+      expect(iframeEl.getAttribute('style')).toBe(
+        'aspect-ratio: 16 / 9; width: 100%; height: auto;'
+      );
+      expect(iframeEl.getAttribute('allow')).toBe(
+        'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
+      );
+      expect(iframeEl.getAttribute('referrerpolicy')).toBe(
+        'strict-origin-when-cross-origin'
+      );
+      expect(iframeEl.getAttribute('allowfullscreen')).toBe('');
+      expect(iframeEl.getAttribute('loading')).toBe('lazy');
+
+      // Check if the iframeEl is wrapped in a div with the expected class
+      expect(iframeEl.parentElement.tagName).toBe('DIV');
+      expect(iframeEl.parentElement.classList).toContain('embed-wrapper');
     });
-    const dom = new JSDOM(modifiedHTML);
-    const document = dom.window.document;
-    const iframeEl = document.querySelector('iframe');
 
-    expect(iframeEl).toBeTruthy();
-    expect(iframeEl.src).toBe('https://www.youtube.com/embed/KZe0C0Qq4p0');
-    expect(iframeEl.width).toBe('560');
-    expect(iframeEl.height).toBe('315');
-    expect(iframeEl.title).toBe('YouTube video player');
-    expect(iframeEl.getAttribute('style')).toBe(
-      'aspect-ratio: 16 / 9; width: 100%; height: auto;'
-    );
-    expect(iframeEl.getAttribute('allow')).toBe(
-      'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
-    );
-    expect(iframeEl.getAttribute('referrerpolicy')).toBe(
-      'strict-origin-when-cross-origin'
-    );
-    expect(iframeEl.getAttribute('allowfullscreen')).toBe('');
-    expect(iframeEl.getAttribute('loading')).toBe('lazy');
+    it('Giphy embeds should return the expected modified HTML', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHashnodeEmbeds.giphy,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const iframeEl = document.querySelector('iframe');
 
-    // Check if the iframeEl is wrapped in a div with the expected class
-    expect(iframeEl.parentElement.tagName).toBe('DIV');
-    expect(iframeEl.parentElement.classList).toContain('embed-wrapper');
+      expect(iframeEl).toBeTruthy();
+      expect(iframeEl.src).toBe('https://giphy.com/embed/VbnUQpnihPSIgIXuZv');
+      expect(iframeEl.width).toBe('100%');
+      expect(iframeEl.height).toBe('100%');
+      expect(iframeEl.title).toBe('Giphy embed');
+      expect(iframeEl.getAttribute('style')).toBe('position: absolute');
+      expect(iframeEl.getAttribute('allowfullscreen')).toBe('');
+
+      // Check if the iframeEl is wrapped in a divs with the expected classes
+      expect(iframeEl.parentElement.tagName).toBe('DIV');
+      expect(iframeEl.parentElement.classList).toContain('giphy-wrapper');
+      expect(iframeEl.parentElement.getAttribute('style')).toBe(
+        'width: 100%; height: 0; padding-bottom: 125%; position: relative;'
+      );
+      expect(iframeEl.parentElement.parentElement.tagName).toBe('DIV');
+      expect(iframeEl.parentElement.parentElement.classList).toContain(
+        'embed-wrapper'
+      );
+    });
+
+    it('Twitter embeds should return the expected modified HTML', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHashnodeEmbeds.twitter,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const blockquoteEl = document.querySelector('blockquote');
+      const scriptEl = document.querySelector('script');
+
+      expect(blockquoteEl).toBeTruthy();
+      expect(blockquoteEl.classList).toContain('twitter-tweet');
+      expect(blockquoteEl.children.length).toBe(1);
+      expect(blockquoteEl.querySelector('a').href).toBe(
+        'https://twitter.com/freeCodeCamp/status/1780642881054609864'
+      );
+      expect(scriptEl).toBeTruthy();
+      expect(scriptEl.src).toBe('https://platform.twitter.com/widgets.js');
+      expect(scriptEl.getAttribute('defer')).toBe('');
+
+      // Check if the blockquoteEl is wrapped in a div with the expected class
+      expect(blockquoteEl.parentElement.tagName).toBe('DIV');
+      expect(blockquoteEl.parentElement.classList).toContain('embed-wrapper');
+    });
+
+    it('X embeds should return the expected modified HTML', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHashnodeEmbeds.x,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const blockquoteEl = document.querySelector('blockquote');
+      const scriptEl = document.querySelector('script');
+
+      expect(blockquoteEl).toBeTruthy();
+      expect(blockquoteEl.classList).toContain('twitter-tweet');
+      expect(blockquoteEl.children.length).toBe(1);
+      expect(blockquoteEl.querySelector('a').href).not.toContain('x.com');
+      expect(blockquoteEl.querySelector('a').href).toBe(
+        'https://twitter.com/freeCodeCamp/status/1793688847299018852'
+      );
+      expect(scriptEl).toBeTruthy();
+      expect(scriptEl.src).toBe('https://platform.twitter.com/widgets.js');
+      expect(scriptEl.getAttribute('defer')).toBe('');
+
+      // Check if the blockquoteEl is wrapped in a div with the expected class
+      expect(blockquoteEl.parentElement.tagName).toBe('DIV');
+      expect(blockquoteEl.parentElement.classList).toContain('embed-wrapper');
+    });
+
+    it('GitHub Gist embeds should return the expected modified HTML', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHashnodeEmbeds.githubGist,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const scriptEl = document.querySelector('script');
+
+      expect(scriptEl).toBeTruthy();
+      expect(scriptEl.src).toBe(
+        'https://gist.github.com/scissorsneedfoodtoo/539dbbd01ebfd36fd8a671124d290f5a.js'
+      );
+
+      // Check if the scriptEl is wrapped in a div with the expected class
+      expect(scriptEl.parentElement.tagName).toBe('DIV');
+      expect(scriptEl.parentElement.classList).toContain('gist-block'); // This gets added by the gist-embed package
+      expect(scriptEl.parentElement.classList).toContain('embed-wrapper');
+    });
+
+    it('iframes in HTML blocks should return the expected modified HTML', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHashnodeEmbeds.iframeInHTMLBlock,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const iframeEl = document.querySelector('iframe');
+
+      expect(iframeEl).toBeTruthy();
+      expect(iframeEl.src).toBe(
+        'https://www.youtube.com/embed/N1pYdEAU9mk?si=BapivyRfMfD99MTc'
+      );
+      expect(iframeEl.width).toBe('560');
+      expect(iframeEl.height).toBe('315');
+      expect(iframeEl.title).toBe(translate('embed-title'));
+
+      // Check if the iframeEl is wrapped in a div with the expected class
+      expect(iframeEl.parentElement.tagName).toBe('DIV');
+      expect(iframeEl.parentElement.classList).toContain('embed-wrapper');
+    });
+
+    it('embeds with no wrapper should return the expected modified HTML', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHashnodeEmbeds.embedNoWrapper,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const iframeEl = document.querySelector('iframe');
+
+      expect(iframeEl).toBeTruthy();
+      expect(iframeEl.src).toBe('https://www.youtube.com/embed/0WjfKQdfeMU');
+      expect(iframeEl.width).toBe('560');
+      expect(iframeEl.height).toBe('315');
+      expect(iframeEl.title).toBe('YouTube video player');
+      expect(iframeEl.getAttribute('style')).toBe(
+        'aspect-ratio: 16 / 9; width: 100%; height: auto;'
+      );
+      expect(iframeEl.getAttribute('allow')).toBe(
+        'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
+      );
+      expect(iframeEl.getAttribute('referrerpolicy')).toBe(
+        'strict-origin-when-cross-origin'
+      );
+      expect(iframeEl.getAttribute('allowfullscreen')).toBe('');
+      expect(iframeEl.getAttribute('loading')).toBe('lazy');
+
+      // Check if the iframeEl is wrapped in a div with the expected class
+      expect(iframeEl.parentElement.tagName).toBe('DIV');
+      expect(iframeEl.parentElement.classList).toContain('embed-wrapper');
+    });
   });
 
-  it('Giphy embeds should return the expected modified HTML', async () => {
-    const modifiedHTML = await modifyHTMLContent({
-      postContent: mockHashnodeEmbeds.giphy,
-      postTitle: 'Test Post',
-      source: 'Hashnode'
+  describe('Hashnode headings', () => {
+    it('Headings with no id should have an id generated', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHeadings.withNoId,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const headingEl = document.querySelector('h2');
+
+      expect(headingEl).toBeTruthy();
+      expect(headingEl.id).toBe('heading-the-typical-workflow');
     });
-    const dom = new JSDOM(modifiedHTML);
-    const document = dom.window.document;
-    const iframeEl = document.querySelector('iframe');
 
-    expect(iframeEl).toBeTruthy();
-    expect(iframeEl.src).toBe('https://giphy.com/embed/VbnUQpnihPSIgIXuZv');
-    expect(iframeEl.width).toBe('100%');
-    expect(iframeEl.height).toBe('100%');
-    expect(iframeEl.title).toBe('Giphy embed');
-    expect(iframeEl.getAttribute('style')).toBe('position: absolute');
-    expect(iframeEl.getAttribute('allowfullscreen')).toBe('');
+    it('Headings with existing ids should keep their original id', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHeadings.withExistingId,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const headingEl = document.querySelector('h2');
 
-    // Check if the iframeEl is wrapped in a divs with the expected classes
-    expect(iframeEl.parentElement.tagName).toBe('DIV');
-    expect(iframeEl.parentElement.classList).toContain('giphy-wrapper');
-    expect(iframeEl.parentElement.getAttribute('style')).toBe(
-      'width: 100%; height: 0; padding-bottom: 125%; position: relative;'
-    );
-    expect(iframeEl.parentElement.parentElement.tagName).toBe('DIV');
-    expect(iframeEl.parentElement.parentElement.classList).toContain(
-      'embed-wrapper'
-    );
-  });
-
-  it('Twitter embeds should return the expected modified HTML', async () => {
-    const modifiedHTML = await modifyHTMLContent({
-      postContent: mockHashnodeEmbeds.twitter,
-      postTitle: 'Test Post',
-      source: 'Hashnode'
+      expect(headingEl).toBeTruthy();
+      expect(headingEl.id).toBe('my-personal-workflow');
     });
-    const dom = new JSDOM(modifiedHTML);
-    const document = dom.window.document;
-    const blockquoteEl = document.querySelector('blockquote');
-    const scriptEl = document.querySelector('script');
 
-    expect(blockquoteEl).toBeTruthy();
-    expect(blockquoteEl.classList).toContain('twitter-tweet');
-    expect(blockquoteEl.children.length).toBe(1);
-    expect(blockquoteEl.querySelector('a').href).toBe(
-      'https://twitter.com/freeCodeCamp/status/1780642881054609864'
-    );
-    expect(scriptEl).toBeTruthy();
-    expect(scriptEl.src).toBe('https://platform.twitter.com/widgets.js');
-    expect(scriptEl.getAttribute('defer')).toBe('');
+    it('Headings with nested elements should have ids generated based on the full text content', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: mockHeadings.withNestedElements,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const document = dom.window.document;
+      const headingEl = document.querySelector('h2');
 
-    // Check if the blockquoteEl is wrapped in a div with the expected class
-    expect(blockquoteEl.parentElement.tagName).toBe('DIV');
-    expect(blockquoteEl.parentElement.classList).toContain('embed-wrapper');
-  });
-
-  it('X embeds should return the expected modified HTML', async () => {
-    const modifiedHTML = await modifyHTMLContent({
-      postContent: mockHashnodeEmbeds.x,
-      postTitle: 'Test Post',
-      source: 'Hashnode'
+      expect(headingEl).toBeTruthy();
+      expect(headingEl.id).toBe('heading-bold-and-emphasized-text');
     });
-    const dom = new JSDOM(modifiedHTML);
-    const document = dom.window.document;
-    const blockquoteEl = document.querySelector('blockquote');
-    const scriptEl = document.querySelector('script');
-
-    expect(blockquoteEl).toBeTruthy();
-    expect(blockquoteEl.classList).toContain('twitter-tweet');
-    expect(blockquoteEl.children.length).toBe(1);
-    expect(blockquoteEl.querySelector('a').href).not.toContain('x.com');
-    expect(blockquoteEl.querySelector('a').href).toBe(
-      'https://twitter.com/freeCodeCamp/status/1793688847299018852'
-    );
-    expect(scriptEl).toBeTruthy();
-    expect(scriptEl.src).toBe('https://platform.twitter.com/widgets.js');
-    expect(scriptEl.getAttribute('defer')).toBe('');
-
-    // Check if the blockquoteEl is wrapped in a div with the expected class
-    expect(blockquoteEl.parentElement.tagName).toBe('DIV');
-    expect(blockquoteEl.parentElement.classList).toContain('embed-wrapper');
-  });
-
-  it('GitHub Gist embeds should return the expected modified HTML', async () => {
-    const modifiedHTML = await modifyHTMLContent({
-      postContent: mockHashnodeEmbeds.githubGist,
-      postTitle: 'Test Post',
-      source: 'Hashnode'
-    });
-    const dom = new JSDOM(modifiedHTML);
-    const document = dom.window.document;
-    const scriptEl = document.querySelector('script');
-
-    expect(scriptEl).toBeTruthy();
-    expect(scriptEl.src).toBe(
-      'https://gist.github.com/scissorsneedfoodtoo/539dbbd01ebfd36fd8a671124d290f5a.js'
-    );
-
-    // Check if the scriptEl is wrapped in a div with the expected class
-    expect(scriptEl.parentElement.tagName).toBe('DIV');
-    expect(scriptEl.parentElement.classList).toContain('gist-block'); // This gets added by the gist-embed package
-    expect(scriptEl.parentElement.classList).toContain('embed-wrapper');
-  });
-
-  it('iframes in HTML blocks should return the expected modified HTML', async () => {
-    const modifiedHTML = await modifyHTMLContent({
-      postContent: mockHashnodeEmbeds.iframeInHTMLBlock,
-      postTitle: 'Test Post',
-      source: 'Hashnode'
-    });
-    const dom = new JSDOM(modifiedHTML);
-    const document = dom.window.document;
-    const iframeEl = document.querySelector('iframe');
-
-    expect(iframeEl).toBeTruthy();
-    expect(iframeEl.src).toBe(
-      'https://www.youtube.com/embed/N1pYdEAU9mk?si=BapivyRfMfD99MTc'
-    );
-    expect(iframeEl.width).toBe('560');
-    expect(iframeEl.height).toBe('315');
-    expect(iframeEl.title).toBe(translate('embed-title'));
-
-    // Check if the iframeEl is wrapped in a div with the expected class
-    expect(iframeEl.parentElement.tagName).toBe('DIV');
-    expect(iframeEl.parentElement.classList).toContain('embed-wrapper');
-  });
-
-  it('embeds with no wrapper should return the expected modified HTML', async () => {
-    const modifiedHTML = await modifyHTMLContent({
-      postContent: mockHashnodeEmbeds.embedNoWrapper,
-      postTitle: 'Test Post',
-      source: 'Hashnode'
-    });
-    const dom = new JSDOM(modifiedHTML);
-    const document = dom.window.document;
-    const iframeEl = document.querySelector('iframe');
-
-    expect(iframeEl).toBeTruthy();
-    expect(iframeEl.src).toBe('https://www.youtube.com/embed/0WjfKQdfeMU');
-    expect(iframeEl.width).toBe('560');
-    expect(iframeEl.height).toBe('315');
-    expect(iframeEl.title).toBe('YouTube video player');
-    expect(iframeEl.getAttribute('style')).toBe(
-      'aspect-ratio: 16 / 9; width: 100%; height: auto;'
-    );
-    expect(iframeEl.getAttribute('allow')).toBe(
-      'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
-    );
-    expect(iframeEl.getAttribute('referrerpolicy')).toBe(
-      'strict-origin-when-cross-origin'
-    );
-    expect(iframeEl.getAttribute('allowfullscreen')).toBe('');
-    expect(iframeEl.getAttribute('loading')).toBe('lazy');
-
-    // Check if the iframeEl is wrapped in a div with the expected class
-    expect(iframeEl.parentElement.tagName).toBe('DIV');
-    expect(iframeEl.parentElement.classList).toContain('embed-wrapper');
   });
 });

--- a/utils/modify-html-helpers.js
+++ b/utils/modify-html-helpers.js
@@ -1,6 +1,8 @@
 import getVideoId from 'get-video-id';
 import { parse } from 'path';
 import { JSDOM } from 'jsdom';
+import sanitizeHtml from 'sanitize-html';
+import slug from 'slug';
 
 export const generateHashnodeEmbedMarkup = async embedURL => {
   try {
@@ -219,3 +221,13 @@ export const stripHTMLTags = str => {
   const dom = new JSDOM(str);
   return dom.window.document.body.textContent || '';
 };
+
+export class HeadingSlugger {
+  static sanitizeSlug(str) {
+    return slug(sanitizeHtml(str, { allowedTags: [] }), { lower: true });
+  }
+
+  getSlug(str) {
+    return HeadingSlugger.sanitizeSlug(str);
+  }
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Related to https://github.com/freeCodeCamp/hashnode-preview/pull/99

<!-- Feel free to add any additional description of changes below this line -->
This PR generates missing ids for headings in Hashnode posts. To do this, we use a method that's similar to what the HN team shared with us a while back. This only looks at headings for Hashnode posts and adds them if they're missing.

This, along with the changes in https://github.com/freeCodeCamp/hashnode-preview/pull/99, should help Abbey and contributing authors create table of contents sections for posts. We can consider removing this once the issue with missing heading ids is fixed for all Hashnode posts.