### PR TITLE
fix: rss links

### DIFF
--- a/cypress/e2e/english/author/author.cy.ts
+++ b/cypress/e2e/english/author/author.cy.ts
@@ -303,7 +303,7 @@ describe('Author page (Hashnode sourced)', () => {
           .should(
             'have.attr',
             'href',
-            'https://feedly.com/i/subscription/feed/http://localhost:8080/news/author/beaucarnes/rss/'
+            'http://localhost:8080/news/author/beaucarnes/rss/'
           )
           .find('svg')
           .should('have.attr', 'data-test-label', 'rss-icon');

--- a/cypress/e2e/english/tag/tag.cy.ts
+++ b/cypress/e2e/english/tag/tag.cy.ts
@@ -2,7 +2,13 @@ import { loadAndCountAllPostCards } from '../../../support/utils/post-cards';
 
 const selectors = {
   tagName: "[data-test-label='tag-name']",
-  tagPostCount: "[data-test-label='tag-post-count']"
+  tagPostCount: "[data-test-label='tag-post-count']",
+  socialMedia: {
+    rss: {
+      link: "[data-test-label='rss-link']",
+      icon: "[data-test-label='rss-icon']"
+    }
+  }
 };
 
 describe('Tag pages (Hashnode sourced)', () => {
@@ -10,11 +16,27 @@ describe('Tag pages (Hashnode sourced)', () => {
     cy.visit('/tag/c-programming/');
   });
 
-  it('should render', () => {
-    cy.contains(selectors.tagName, '#C PROGRAMMING');
+  context('General tests', () => {
+    it('should render', () => {
+      cy.contains(selectors.tagName, '#C PROGRAMMING');
+    });
+
+    it('the number of total posts should match the post count at the top of the page (1)', () => {
+      loadAndCountAllPostCards(selectors.tagPostCount);
+    });
   });
 
-  it('the number of total posts should match the post count at the top of the page (1)', () => {
-    loadAndCountAllPostCards(selectors.tagPostCount);
+  // Note: All tags should have an RSS link and icon
+  context('RSS', () => {
+    it('should show an RSS link and icon with the expected attributes', () => {
+      cy.get(selectors.socialMedia.rss.link)
+        .should(
+          'have.attr',
+          'href',
+          'http://localhost:8080/news/tag/c-programming/rss/'
+        )
+        .find('svg')
+        .should('have.attr', 'data-test-label', 'rss-icon');
+    });
   });
 });

--- a/cypress/e2e/espanol/author/author.cy.ts
+++ b/cypress/e2e/espanol/author/author.cy.ts
@@ -180,11 +180,13 @@ describe('Author page (Ghost sourced)', () => {
           cy.visit('/author/rafael/');
         });
 
-        // TODO: Links for RSS feeds are currently broken, so fix and test them in
-        // a future PR
         it('should show an RSS link and icon', () => {
           cy.get(selectors.socialMedia.rss.link)
-            // .should('have.attr', 'href', 'https://feedly.com/i/subscription/feed/http://localhost:8080/news/author/rafael/rss/')
+            .should(
+              'have.attr',
+              'href',
+              'http://localhost:8080/espanol/news/author/rafael/rss/'
+            )
             .find('svg')
             .should('have.attr', 'data-test-label', 'rss-icon');
         });

--- a/cypress/e2e/espanol/tag/tag.cy.ts
+++ b/cypress/e2e/espanol/tag/tag.cy.ts
@@ -2,7 +2,13 @@ import { loadAndCountAllPostCards } from '../../../support/utils/post-cards';
 
 const selectors = {
   tagName: "[data-test-label='tag-name']",
-  tagPostCount: "[data-test-label='tag-post-count']"
+  tagPostCount: "[data-test-label='tag-post-count']",
+  socialMedia: {
+    rss: {
+      link: "[data-test-label='rss-link']",
+      icon: "[data-test-label='rss-icon']"
+    }
+  }
 };
 
 describe('Tag pages (Ghost sourced)', () => {
@@ -15,11 +21,27 @@ describe('Tag pages (Ghost sourced)', () => {
     cy.visit('/tag/javascript/');
   });
 
-  it('should render', () => {
-    cy.contains(selectors.tagName, '#JAVASCRIPT');
+  context('General tests', () => {
+    it('should render', () => {
+      cy.contains(selectors.tagName, '#JAVASCRIPT');
+    });
+
+    it('the number of total posts should match the post count at the top of the page (4)', () => {
+      loadAndCountAllPostCards(selectors.tagPostCount);
+    });
   });
 
-  it('the number of total posts should match the post count at the top of the page (4)', () => {
-    loadAndCountAllPostCards(selectors.tagPostCount);
+  // Note: All tags should have an RSS link and icon
+  context('RSS', () => {
+    it('should show an RSS link and icon with the expected attributes', () => {
+      cy.get(selectors.socialMedia.rss.link)
+        .should(
+          'have.attr',
+          'href',
+          'http://localhost:8080/espanol/news/tag/javascript/rss/'
+        )
+        .find('svg')
+        .should('have.attr', 'data-test-label', 'rss-icon');
+    });
   });
 });

--- a/src/_includes/layouts/tag.njk
+++ b/src/_includes/layouts/tag.njk
@@ -18,6 +18,17 @@
                 {% t 'tag.multiple-posts', { postCount: postCount } %}
             {% endif %}
         </h2>
+        <div class="social-links">
+            <a
+                class="social-link social-link-rss"
+                href="{{ (tag.path + '/rss/') | htmlBaseUrl(site.url) }}"
+                target="_blank"
+                rel="noopener"
+                data-test-label="rss-link"
+            >
+                {% include "partials/icons/rss.njk" %}
+            </a>
+        </div>
 
         <div class="tags-row">
             {% for tag in popularTags %}

--- a/src/_includes/partials/author-info.njk
+++ b/src/_includes/partials/author-info.njk
@@ -135,7 +135,7 @@
             {% endif %}
             <a
                 class="social-link social-link-rss"
-                href="https://feedly.com/i/subscription/feed/{{ (author.path + '/rss/') | htmlBaseUrl(site.url) }}"
+                href="{{ (author.path + '/rss/') | htmlBaseUrl(site.url) }}"
                 target="_blank"
                 rel="noopener"
                 data-test-label="rss-link"


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Feedly links on author pages have been broken for some time, so this PR simplifies existing RSS links by linking directly to the feed itself. This way people can use whichever RSS reader they'd like to use.

This also adds an RSS icon to tag pages with a direct link to feeds to make it more obvious that people can track posts via tag as well.

Finally, this updates the English and Spanish author and tag page e2e tests for these modified or new links on those pages.