### PR TITLE
fix(hashnode): retry on 5xx during build fetch

### DIFF
--- a/.github/workflows/deploy-eng.yml
+++ b/.github/workflows/deploy-eng.yml
@@ -72,7 +72,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build site
-        run: pnpm run build
+        run: |
+          pnpm run build || {
+            echo "::warning::Build failed after in-app retries exhausted. Waiting 2 minutes before final job-level retry..."
+            sleep 120
+            echo "::notice::Retrying build site step..."
+            pnpm run build
+          }
         env:
           NODE_ENV: production
 

--- a/utils/hashnode/fetch-from-hashnode.js
+++ b/utils/hashnode/fetch-from-hashnode.js
@@ -138,14 +138,20 @@ export const fetchFromHashnode = async contentType => {
 
         success = true;
       } catch (error) {
-        if (error.message.includes('ECONNRESET') && retries > 1) {
+        const status = error.response?.status;
+        const isTransient =
+          status >= 500 ||
+          error.message.includes('ECONNRESET') ||
+          error.message.includes('ETIMEDOUT') ||
+          error.message.includes('ECONNREFUSED');
+        if (isTransient && retries > 1) {
           console.log(
-            `Connection reset error. Retrying... (${retries - 1} attempts left)`
+            `Transient error (${status || error.code || 'network'}). Retrying... (${retries - 1} attempts left)`
           );
           retries--;
-          await wait(10000); // Wait for 10 seconds before retrying
+          await wait(60000); // 60s aligns with Cloudflare retry_after hint on 502s
         } else {
-          throw error; // If it's not a connection reset or no more retries, rethrow the error
+          throw error; // Non-transient, or retries exhausted
         }
       }
     }


### PR DESCRIPTION
The retry predicate in fetchFromHashnode only matched ECONNRESET, so transient Cloudflare 502s from the Hashnode GraphQL origin(zone gql-zt6e.onrender.com) fell straight through to a rethrow. Recent ENG deploys have failed mid-pagination around post page 4380 and required manual workflow re-runs.

Broaden the predicate to any HTTP 5xx response plus ETIMEDOUT and ECONNREFUSED. Bump the per-retry wait from 10s to 60s to match Cloudflare's retry_after hint on origin_bad_gateway, so 3 attempts cover ~3 min of upstream recovery.

Also add a single 2-min job-level retry on the Build site step in deploy-eng.yml as defense-in-depth if in-app retries are exhausted. i18n workflow left untouched - last 15 runs are all green on attempt 1, and the per-locale Hashnode fetches are too small to hit the same pagination-window flake.