### PR TITLE
fix: dark mode contrast

### DIFF
--- a/src/_includes/assets/css/global.css
+++ b/src/_includes/assets/css/global.css
@@ -278,6 +278,11 @@ body {
   font-feature-settings: 'liga1' on;
 }
 
+html.dark-mode body {
+  color: var(--secondary-color);
+  background: var(--secondary-background);
+}
+
 ::selection {
   text-shadow: none;
   background: var(--selection-color);
@@ -361,6 +366,10 @@ dt {
   color: var(--primary-color);
   font-weight: 500;
   text-align: right;
+}
+
+html.dark-mode dt {
+  color: var(--secondary-color);
 }
 
 dd {

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -143,6 +143,11 @@ html.dark-mode body {
   color: var(--primary-background);
 }
 
+html.dark-mode .under-header-content {
+  background-color: var(--primary-background);
+  color: var(--secondary-color);
+}
+
 .site-title {
   z-index: 10;
   margin: 0;

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2196,6 +2196,11 @@ p:has(mjx-container.MathJax) {
   font-size: 16px;
 }
 
+html.dark-mode .site-footer {
+  background: var(--tertiary-background);
+  color: var(--tertiary-color);
+}
+
 .footer-top {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(30.5em, 1fr));
@@ -2223,6 +2228,10 @@ p:has(mjx-container.MathJax) {
   color: var(--secondary-color);
   text-decoration: none;
   padding: 2px;
+}
+
+html.dark-mode .site-footer a {
+  color: var(--tertiary-color);
 }
 
 .site-footer a:hover {

--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -638,6 +638,10 @@ html.dark-mode .post-card {
   color: var(--primary-color);
 }
 
+html.dark-mode .post-card-content-link {
+  color: var(--secondary-color);
+}
+
 .post-card-content-link:hover {
   text-decoration: none;
 }
@@ -659,6 +663,10 @@ html.dark-mode .post-card {
 
 .post-card-title a {
   color: var(--primary-color);
+}
+
+html.dark-mode .post-card-title a {
+  color: var(--secondary-color);
 }
 
 .post-card-content {
@@ -941,6 +949,10 @@ html.dark-mode .page-template.site-main {
   color: var(--primary-color);
 }
 
+html.dark-mode .post-full-title {
+  color: var(--secondary-color);
+}
+
 .date-divider {
   display: inline-block;
   margin: 0 6px 1px;
@@ -1052,6 +1064,10 @@ html.dark-mode .post-full-content {
   color: var(--primary-color);
   word-break: break-word;
   text-decoration: underline;
+}
+
+html.dark-mode .post-full-content a {
+  color: var(--secondary-color);
 }
 
 .post-full-content a:hover {
@@ -1544,6 +1560,10 @@ pre.runkit-element {
   text-transform: uppercase;
 }
 
+html.dark-mode .post-full-authors-content p {
+  color: var(--secondary-color);
+}
+
 .post-full-authors-content a {
   display: inline-block;
   color: var(--secondary-color);
@@ -1703,7 +1723,7 @@ html.dark-mode .author-list-item .author-card:before {
 }
 
 html.dark-mode .read-next-card-header-title {
-  color: var(--primary-color);
+  color: var(--secondary-color);
 }
 
 .read-next-card-header-title a {
@@ -1955,6 +1975,10 @@ html.dark-mode .kg-bookmark-card {
   border-radius: 3px;
 }
 
+html.dark-mode .post-full-content .kg-bookmark-container {
+  color: var(--secondary-color);
+}
+
 .kg-bookmark-content {
   display: flex;
   flex-direction: column;
@@ -1969,6 +1993,10 @@ html.dark-mode .kg-bookmark-card {
   line-height: 1.5em;
   font-weight: 600;
   color: var(--primary-color);
+}
+
+html.dark-mode .kg-bookmark-title {
+  color: var(--secondary-color);
 }
 
 .post-full-content .kg-bookmark-container:hover .kg-bookmark-title {
@@ -2422,9 +2450,20 @@ p.footer-donation a:hover {
   color: var(--primary-color);
 }
 
+html.dark-mode #readMoreBtn {
+  border: 2px solid var(--secondary-color);
+  background: var(--tertiary-background);
+  color: var(--secondary-color);
+}
+
 #readMoreBtn:hover {
   background: var(--primary-color);
   color: var(--secondary-background);
+}
+
+html.dark-mode #readMoreBtn:hover {
+  background: var(--secondary-color);
+  color: var(--primary-background);
 }
 
 /* 12. Tags
@@ -2486,9 +2525,21 @@ a.cta-button {
   padding: 0 20px;
 }
 
+html.dark-mode button.cta-button,
+html.dark-mode a.cta-button {
+  border: 3px solid var(--secondary-color);
+  background: var(--quaternary-background);
+  color: var(--secondary-color);
+}
+
 .cta-button:hover {
   background: var(--primary-color);
   color: var(--tertiary-background);
+}
+
+html.dark-mode .cta-button:hover {
+  background: var(--secondary-color);
+  color: var(--quaternary-background);
 }
 
 @media (min-width: 700px) {

--- a/src/_includes/assets/css/variables.css
+++ b/src/_includes/assets/css/variables.css
@@ -15,7 +15,7 @@
   --gray45: #858591;
   --gray15: #d0d0d5;
   --gray10: #dfdfe2;
-  --gray05: #f5f6f7;
+  --gray05: #eeeef0;
   --gray00: #fff;
   --header-height: 38px;
   /* Font */

--- a/src/_includes/assets/css/variables.css
+++ b/src/_includes/assets/css/variables.css
@@ -15,7 +15,7 @@
   --gray45: #858591;
   --gray15: #d0d0d5;
   --gray10: #dfdfe2;
-  --gray05: #eeeef0;
+  --gray05: #f5f6f7;
   --gray00: #fff;
   --header-height: 38px;
   /* Font */


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
This PR includes a handful of fixes for colors in dark mode.

It sets the color for text and links for post cards and pages to the secondary color variable, which is now set to `#f5f6f7` to match what we have in the main repo. It also fixes the colors for the under header section on author and tag pages so text and social link buttons are visible, and adds colors to the footer section for better separation, similar to what we have on Learn.

There are some photos below for reference.

- Current author / tag pages:

<img width="816" height="672" alt="image" src="https://github.com/user-attachments/assets/cc715544-099b-4d57-8547-7a5b36c929a5" />

- Author / tag pages with updates here:

<img width="816" height="672" alt="image" src="https://github.com/user-attachments/assets/b12357e6-a3ff-4a67-8dac-47f5a0f8c712" />

- Current footer:

<img width="816" height="672" alt="image" src="https://github.com/user-attachments/assets/c47c925e-b474-4095-9f01-325593748262" />

- Footer with updates here:

<img width="816" height="672" alt="image" src="https://github.com/user-attachments/assets/ddef9404-536d-4845-aa7b-446d3c714e39" />
