### PR TITLE
fix: add background color to transparent images

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -1166,6 +1166,27 @@ html.dark-mode .post-full-content a {
   }
 }
 
+/* Add background color for transparent images (logos, diagrams, line art)
+in dark mode. The selectors ending in ? or # catch URLs with a query string
+or hash after the extension. */
+html.dark-mode .post-full-content img[src$='.png' i],
+html.dark-mode .post-full-content img[src*='.png?' i],
+html.dark-mode .post-full-content img[src*='.png#' i],
+html.dark-mode .post-full-content img[src$='.svg' i],
+html.dark-mode .post-full-content img[src*='.svg?' i],
+html.dark-mode .post-full-content img[src*='.svg#' i] {
+  background-color: var(--gray00);
+}
+
+/* SVGs are always line art that often go to the edges of their containers,
+so give them some extra padding in dark mode. This isn't as safe for PNGs, which
+can be transparent screenshots. */
+html.dark-mode .post-full-content img[src$='.svg' i],
+html.dark-mode .post-full-content img[src*='.svg?' i],
+html.dark-mode .post-full-content img[src*='.svg#' i] {
+  padding: 0.5em;
+}
+
 /* Image captions
 
 Usage (In Ghost editor):


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Currently, transparent SVGs and PNGs are difficult to see in dark mode against the dark blue background of post bodies. These changes add a white background color to all SVGs and PNGs in the main content area of posts while in dark mode. A bit of padding is added to SVGs, too, because lines often go right up to the edges.

Here are some before and after images of the sponsors page:

<img width="1420" height="1040" alt="image" src="https://github.com/user-attachments/assets/302e3958-ea57-48c5-bca9-75aa8a6c30af" />

<img width="1420" height="1014" alt="image" src="https://github.com/user-attachments/assets/96d72095-7463-4124-a443-897596150243" />