### PR TITLE
fix: set blockquote children max-width

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -1213,6 +1213,12 @@ Usage (In Ghost editor):
   border-left: var(--dark-blue) 3px solid;
 }
 
+/* Keep blockquote children from stretching blockquote elements
+while making sure images don't stretch */
+.post-full-content blockquote > * {
+  max-width: 100%;
+}
+
 .post-full-content blockquote p {
   margin: 0 0 1em;
   color: inherit;


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
We got a report that a large image is causing the `blockquote` element to stretch past the main content column width. This update sets `max-width: 100%` on blockquote element's children to keep them contained.

Here's a problematic post with the current styles:

<img width="1470" height="828" alt="Screenshot 2026-09-09 at 5 39 34 PM" src="https://github.com/user-attachments/assets/2f475486-607f-4f8c-8c46-5ad6c273e142" />

And here's the same post with the updated styles:

<img width="1470" height="828" alt="Screenshot 2026-09-09 at 5 39 07 PM" src="https://github.com/user-attachments/assets/7f3f8ded-3800-4352-b29d-5c7aedffdff7" />