### PR TITLE
fix: post body images

### DIFF
--- a/src/_includes/assets/css/screen.css
+++ b/src/_includes/assets/css/screen.css
@@ -2734,12 +2734,7 @@ a.banner:hover span {
   visibility: hidden;
 }
 
-/* Adjust image and video widths when ads are enabled */
-/* Ghost editor images */
-.ad-layout .post-full-content .kg-image-card img,
-/* Markdown images */
-.ad-layout .post-full-content p img,
-/* HTML video */
+.ad-layout .post-full-content img,
 .ad-layout .post-full-content video {
   max-width: 100%;
 }

--- a/utils/modify-html-content.js
+++ b/utils/modify-html-content.js
@@ -76,6 +76,19 @@ export const modifyHTMLContent = async ({ postContent, postTitle, source }) => {
       if (!image.alt) setDefaultAlt(image);
 
       image.setAttribute('loading', 'lazy');
+
+      // Strip inline margins from Hashnode so the stylesheet controls image spacing
+      // (Ghost images have no inline margin)
+      for (const property of [
+        'margin',
+        'margin-top',
+        'margin-right',
+        'margin-bottom',
+        'margin-left'
+      ]) {
+        image.style.removeProperty(property);
+      }
+      if (!image.getAttribute('style')?.trim()) image.removeAttribute('style');
     }),
 
     iframes.map(async iframe => {

--- a/utils/modify-html-content.test.js
+++ b/utils/modify-html-content.test.js
@@ -264,4 +264,50 @@ describe('modifyHTMLContent', () => {
       expect(headingEl.id).toBe('heading-bold-and-emphasized-text');
     });
   });
+
+  describe('Body images', () => {
+    // A URL that fails to resolve so getImageDimensions falls back without a
+    // network round trip.
+    const src = 'http://127.0.0.1:1/image.png';
+
+    it('strips the inline margin Hashnode adds, keeping other inline styles', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: `<img src="${src}" alt="A chart" style="width: 300px; margin: 0 auto">`,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const imageEl = dom.window.document.querySelector('img');
+
+      expect(imageEl.style.margin).toBe('');
+      expect(imageEl.style.marginLeft).toBe('');
+      expect(imageEl.style.width).toBe('300px');
+    });
+
+    it('drops the style attribute entirely when only an inline margin was set', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: `<img src="${src}" alt="A chart" style="display:block;margin:0 auto">`,
+        postTitle: 'Test Post',
+        source: 'Hashnode'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const imageEl = dom.window.document.querySelector('img');
+
+      expect(imageEl.style.margin).toBe('');
+      expect(imageEl.getAttribute('style')).toBe('display: block;');
+    });
+
+    it('is a no-op for images without an inline margin (e.g. Ghost)', async () => {
+      const modifiedHTML = await modifyHTMLContent({
+        postContent: `<figure class="kg-card kg-image-card"><img src="${src}" alt="A chart"></figure>`,
+        postTitle: 'Test Post',
+        source: 'Ghost'
+      });
+      const dom = new JSDOM(modifiedHTML);
+      const imageEl = dom.window.document.querySelector('img');
+
+      expect(imageEl.hasAttribute('style')).toBe(false);
+      expect(imageEl.closest('figure').classList).toContain('kg-image-card');
+    });
+  });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
Until recently, Hashnode images in post bodies have been wrapped in `p` elements, so their width and margins were styled.

Currently, it seems like Hashnode images are returned without the `p` wrapper, and with some inline margin styling.

This PR strips out the inline margin styles during the build and tweaks the CSS slightly to fix the width and spacing.

Here's a post that's currently affected: https://www.freecodecamp.org/news/how-to-build-ai-systems-that-know-when-they-don-t-know/

A screenshot of the issue from that post:

<img width="735" height="561" alt="image" src="https://github.com/user-attachments/assets/461aff8f-8ccd-42c3-b7da-2e29a833d8aa" />

And what it looks like after these fixes:

<img width="736" height="582" alt="image" src="https://github.com/user-attachments/assets/b04c8ffd-6a8a-4d84-89ba-7cee51997c53" />